### PR TITLE
feat(issue-11): assignment contract + grouped validation + boss resolution (T1)

### DIFF
--- a/src/serializer/bosses.ts
+++ b/src/serializer/bosses.ts
@@ -1,0 +1,48 @@
+/**
+ * The baked 14-boss SOO catalog (ADR-0001) and boss resolution.
+ *
+ * Vocabulary is source data — never read from the Google Sheet at runtime.
+ * Events are used verbatim (abbr suffixes already embedded, e.g. "Encounter
+ * Start (IMM)"); `sheetName` is the block-detection key (e.g. "SPOILS OF
+ * PANDAREN" ≠ WCL "Spoils of Pandaria").
+ */
+import { readFileSync } from 'node:fs';
+
+export interface SooBoss {
+  id: string;
+  wclName: string;
+  abbr: string;
+  sheetName: string;
+  events: string[];
+}
+
+/** Group tags the export grid accepts in the PLAYER/CLASS/ALL column. */
+export const GROUP_TAGS = ['ALL', 'MELEEDPS', 'RANGEDDPS'] as const;
+
+let cache: SooBoss[] | undefined;
+
+/** All 14 SOO bosses, in sheet order (from src/data/soo-encounters.json). */
+export function allSooBosses(): SooBoss[] {
+  if (cache) return cache;
+  const url = new URL('../data/soo-encounters.json', import.meta.url);
+  cache = (JSON.parse(readFileSync(url, 'utf8')) as { encounters: SooBoss[] }).encounters;
+  return cache;
+}
+
+/**
+ * Resolve an encounter key to a boss definition. Accepts the baked `id`,
+ * `wclName`, or `sheetName` — case-insensitive and trimmed. Returns undefined
+ * for an unknown or empty key. Abbreviations (e.g. "PAR") are NOT resolution
+ * keys — they identify event suffixes, not encounters.
+ */
+export function resolveBoss(key: string | null | undefined): SooBoss | undefined {
+  if (!key) return undefined;
+  const k = key.trim().toLowerCase();
+  if (!k) return undefined;
+  return allSooBosses().find(
+    (b) =>
+      b.id.toLowerCase() === k ||
+      b.wclName.toLowerCase() === k ||
+      b.sheetName.toLowerCase() === k,
+  );
+}

--- a/src/serializer/validate.ts
+++ b/src/serializer/validate.ts
@@ -1,0 +1,105 @@
+/**
+ * Plan validation against a resolved boss — the serializer's hard gate.
+ *
+ * Returns ALL violations in one pass (grouped), with the legal values where
+ * they're known. The renderer (T2) consumes this before emitting CSV; the CLI
+ * wiring (T5) surfaces the grouped errors loudly. Validation scope:
+ *
+ *   - shape/required fields + field types   -> Valibot schema (assignmentSchema)
+ *   - event in the boss's canonical vocabulary
+ *   - roleTag a resolved sheet role or a group tag
+ *   - occurrence a single count or a comma-separated list of counts
+ *
+ * An empty plan validates (scaffolding-only output is legal).
+ */
+import * as v from 'valibot';
+import { assignmentSchema } from '../shared/assignments-schema.ts';
+import type { Assignment } from '../shared/assignments-schema.ts';
+import { GROUP_TAGS } from './bosses.ts';
+import type { SooBoss } from './bosses.ts';
+
+export interface ValidationIssue {
+  /** Index of the offending assignment (-1 for whole-plan issues). */
+  index: number;
+  /** Field the issue is about, when it's a single field. */
+  field?: string;
+  /** Human-readable message naming the offending value. */
+  message: string;
+  /** The valid set, when known (canonical events, allowed role tags). */
+  legalValues?: string[];
+}
+
+export interface PlanValidation {
+  ok: boolean;
+  errors: ValidationIssue[];
+}
+
+export interface ValidateOptions {
+  /** The resolved boss (from resolveBoss) — canon of the event vocabulary. */
+  boss?: SooBoss;
+  /** The resolved roster: keys of the role mappings = allowed role tags. */
+  roleMappings?: Record<string, unknown> | null;
+}
+
+/** A single count or a comma-separated list of counts, e.g. "1", "1,4", "1, 4". */
+const occurrenceListRe = /^\s*\d+(?:\s*,\s*\d+)*\s*$/;
+
+export function validateAssignments(input: unknown, opts: ValidateOptions = {}): PlanValidation {
+  const errors: ValidationIssue[] = [];
+  const { boss, roleMappings } = opts;
+  const allowedTags = [...GROUP_TAGS, ...Object.keys(roleMappings ?? {})];
+
+  if (!boss) {
+    errors.push({ index: -1, field: 'boss', message: 'A boss/encounter is required to validate a plan — resolve it with resolveBoss().' });
+  }
+  if (!Array.isArray(input)) {
+    errors.push({ index: -1, message: 'Assignments must be an array.' });
+    return { ok: false, errors };
+  }
+
+  // Schema-parse issues cover shape, required fields and field types. An
+  // off-vocabulary event / unknown tag / malformed comma-list passes the
+  // schema (strings), so those come from the semantic checks below.
+  const parsed = v.safeParse(v.array(assignmentSchema), input);
+  if (!parsed.success) {
+    for (const issue of parsed.issues) {
+      const index = typeof issue.path?.[0]?.key === 'number' ? issue.path[0].key : -1;
+      const field = typeof issue.path?.[1]?.key === 'string' ? issue.path[1].key : undefined;
+      errors.push({ index, field, message: issue.message });
+    }
+    return { ok: false, errors };
+  }
+
+  const assignments = parsed.output;
+  for (const [index, a] of assignments.entries()) {
+    if (boss && !boss.events.includes(a.event)) {
+      errors.push({
+        index,
+        field: 'event',
+        message: `event "${a.event}" is not in the canonical vocabulary for ${boss.wclName}.`,
+        legalValues: boss.events,
+      });
+    }
+    if (!allowedTags.includes(a.roleTag)) {
+      errors.push({
+        index,
+        field: 'roleTag',
+        message: `roleTag "${a.roleTag}" is not a resolved sheet role or a group tag (ALL / MELEEDPS / RANGEDDPS).`,
+        legalValues: allowedTags,
+      });
+    }
+    const occBad =
+      typeof a.occurrence === 'number'
+        ? !Number.isInteger(a.occurrence) || a.occurrence < 0
+        : !occurrenceListRe.test(a.occurrence);
+    if (occBad) {
+      errors.push({
+        index,
+        field: 'occurrence',
+        message: `occurrence "${String(a.occurrence)}" must be a single count or a comma-separated list of counts (e.g. "1,4").`,
+      });
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/src/shared/assignments-schema.ts
+++ b/src/shared/assignments-schema.ts
@@ -7,12 +7,20 @@ import * as v from 'valibot';
  */
 export const assignmentSchema = v.object({
   event: v.string(),
-  occurrence: v.number(),
+  // A single count or a comma-separated list of counts ("1", "1,4") per the
+  // sheet's COUNT / HEALTH % convention. Widened from number-only (backward
+  // compatible: existing plans carry numbers).
+  occurrence: v.union([v.number(), v.string()]),
   roleTag: v.string(),
   timingOffset: v.number(),
   spellName: v.string(),
   notes: v.string(),
   spellId: v.string(),
+  // Sheet-compliant extras (optional — legacy plans omit them):
+  // OVERRIDE TTS  -> tts
+  // CD #          -> cd
+  tts: v.optional(v.string()),
+  cd: v.optional(v.number()),
 });
 
 export type Assignment = v.InferOutput<typeof assignmentSchema>;

--- a/test/unit/serializer-validation.test.ts
+++ b/test/unit/serializer-validation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the sheet-serializer corner shipped by T1: the extended
+ * assignment contract, boss resolution, and grouped plan validation.
+ *
+ * This is the single new test seam for the serializer feature — pure contract
+ * tests: no .env keys, no network, no model. Runs under `npm test`.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+import * as v from 'valibot';
+
+import { assignmentSchema } from '../../src/shared/assignments-schema.ts';
+import type { Assignment } from '../../src/shared/assignments-schema.ts';
+import { allSooBosses, resolveBoss, GROUP_TAGS } from '../../src/serializer/bosses.ts';
+import { validateAssignments } from '../../src/serializer/validate.ts';
+
+const paragons = resolveBoss('Paragons of the Klaxxi');
+assert.ok(paragons, 'Paragons must resolve for the fixture');
+
+/** Hand-written representative role mappings (tags the plan is allowed to use). */
+const ROLE_MAPPINGS = {
+  PROTPALA1: { name: 'Paladino' },
+  DISC1: { name: 'Sacred' },
+  RSHAM1: { name: 'Totem' },
+};
+
+const base = (over: Partial<Assignment> = {}): Assignment => ({
+  event: 'Reave',
+  occurrence: 1,
+  roleTag: 'PROTPALA1',
+  timingOffset: 0,
+  spellName: 'Shield Wall',
+  notes: '',
+  spellId: '871',
+  ...over,
+});
+
+test('T1: a valid plan passes for Paragons (canonical events, resolved + group tags)', () => {
+  const plan: Assignment[] = [
+    base({ event: 'Reave', roleTag: 'PROTPALA1' }),
+    base({ event: 'Whirling', roleTag: 'DISC1' }),
+    base({ event: 'Encounter Start (PAR)', roleTag: 'ALL', spellName: 'Bloodlust' }),
+    base({ event: 'Hurl Amber', roleTag: 'MELEEDPS' }),
+    base({ event: 'Death from Above (PAR)', roleTag: 'RSHAM1', timingOffset: -20 }),
+    base({ event: 'Whirling', roleTag: 'RANGEDDPS', occurrence: '1,4' }),
+  ];
+  const r = validateAssignments(plan, { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+  assert.equal(r.errors.length, 0);
+});
+
+test('T1: every one of the 14 bosses accepts its own canonical vocabulary', () => {
+  const bosses = allSooBosses();
+  assert.equal(bosses.length, 14);
+  for (const boss of bosses) {
+    const plan: Assignment[] = boss.events.map((event) =>
+      base({ event, roleTag: 'ALL', spellName: 'Power Word: Barrier' }));
+    const r = validateAssignments(plan, { boss, roleMappings: {} });
+    assert.equal(r.ok, true, `${boss.id}: ${JSON.stringify(r.errors.slice(0, 3))}`);
+  }
+});
+
+test('T1: an off-vocabulary event is rejected, naming the offending event and the valid set', () => {
+  const plan = [base({ event: 'Calamity' })]; // "Calamity" belongs to Fallen Protectors, not Paragons
+  const r = validateAssignments(plan, { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(r.ok, false);
+  const issue = r.errors.find((e) => e.field === 'event');
+  assert.ok(issue, 'expected an event-field issue');
+  assert.match(issue.message, /Calamity/);
+  assert.deepEqual(issue.legalValues, paragons.events);
+});
+
+test('T1: unknown tag, off-vocab event and malformed comma-list are reported together', () => {
+  const plan = [base({ event: 'Calamity', roleTag: 'BOGUSTAG', occurrence: '1,,4' })];
+  const r = validateAssignments(plan, { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(r.ok, false);
+  const fields = r.errors.map((e) => e.field).sort();
+  assert.deepEqual(fields, ['event', 'occurrence', 'roleTag']);
+});
+
+test('T1: a missing required field and a non-numeric timing are grouped errors', () => {
+  // spellName missing on the first row, timingOffset a string on the second
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const plan: any[] = [
+    { event: 'Reave', occurrence: 1, roleTag: 'PROTPALA1', timingOffset: 0, notes: '', spellId: '' },
+    { ...base(), timingOffset: 'abc' },
+  ];
+  const r = validateAssignments(plan, { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.field === 'spellName'), 'missing spellName reported');
+  assert.ok(r.errors.some((e) => e.field === 'timingOffset'), 'non-numeric timing reported');
+});
+
+test('T1: boss resolution accepts id, WCL name and sheet name (case-insensitive); unknown is undefined', () => {
+  assert.equal(resolveBoss('paragons-of-the-klaxxi')?.id, 'paragons-of-the-klaxxi');
+  assert.equal(resolveBoss('Paragons of the Klaxxi')?.id, 'paragons-of-the-klaxxi');
+  assert.equal(resolveBoss('PARAGONS OF THE KLAXXI')?.id, 'paragons-of-the-klaxxi');
+  assert.equal(resolveBoss('SPOILS OF PANDAREN')?.id, 'spoils-of-pandaria'); // sheet-name key, WCL-spelled id
+  assert.equal(resolveBoss('Garrosh Hellscream')?.id, 'garrosh-hellscream');
+  assert.equal(resolveBoss('immerseus')?.id, 'immerseus');
+  assert.equal(resolveBoss('GAR'), undefined); // abbreviation is not a resolution key
+  assert.equal(resolveBoss('nope'), undefined);
+  assert.equal(resolveBoss(''), undefined);
+  assert.equal(resolveBoss(undefined), undefined);
+});
+
+test('T1: backward compatibility — legacy plan without tts/cd and single-number occurrence validates', () => {
+  assert.equal(v.safeParse(v.array(assignmentSchema), [base()]).success, true);
+  const r = validateAssignments([base()], { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(r.ok, true);
+});
+
+test('T1: occurrence accepts a single count or a comma-list; rejects malformed lists and negatives', () => {
+  const ok1 = validateAssignments([base({ occurrence: '1,4' })], { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(ok1.ok, true, JSON.stringify(ok1.errors));
+  const ok2 = validateAssignments([base({ occurrence: '1, 4' })], { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(ok2.ok, true);
+  assert.equal(validateAssignments([base({ occurrence: '1.5' })], { boss: paragons, roleMappings: ROLE_MAPPINGS }).ok, false);
+  assert.equal(validateAssignments([base({ occurrence: -3 })], { boss: paragons, roleMappings: ROLE_MAPPINGS }).ok, false);
+});
+
+test('T1: timing offsets accept negatives and fractions; empty plan is scaffolding-only (valid)', () => {
+  const r = validateAssignments(
+    [base({ timingOffset: -20, occurrence: 1 }), base({ timingOffset: 0.5, occurrence: 2 })],
+    { boss: paragons, roleMappings: ROLE_MAPPINGS },
+  );
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+  const empty = validateAssignments([], { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(empty.ok, true);
+});
+
+test('T1: validation requires a resolved boss and an assignments array', () => {
+  const noBoss = validateAssignments([base()], { roleMappings: ROLE_MAPPINGS });
+  assert.equal(noBoss.ok, false);
+  const notArray = validateAssignments(null, { boss: paragons, roleMappings: ROLE_MAPPINGS });
+  assert.equal(notArray.ok, false);
+  assert.equal(notArray.errors.length, 1);
+  assert.ok(notArray.errors[0].message.includes('array'));
+});
+
+test('T1: GROUP_TAGS is the canonical group-tag set', () => {
+  assert.deepEqual([...GROUP_TAGS], ['ALL', 'MELEEDPS', 'RANGEDDPS']);
+});


### PR DESCRIPTION
Closes the T1 slice of issue #2 via issue #11.

- **Contract** (`src/shared/assignments-schema.ts`): `occurrence` widens to a single count or a comma-separated list (`"1,4"`); optional `tts` (OVERRIDE TTS) and `cd` (CD #). Backward compatible — legacy plans and the agents' tool schema keep validating.
- **Boss resolution** (`src/serializer/bosses.ts`): loads the baked 14-boss catalog (ADR-0001); `resolveBoss` matches id / WCL name / sheet name case-insensitively; `GROUP_TAGS` constant.
- **Validation** (`src/serializer/validate.ts`): `validateAssignments` returns ALL violations in one pass with the legal values (schema shape → event vocabulary → role tags → occurrence list/numeric).

Tests: 11 new contract tests in `test/unit/serializer-validation.test.ts` — all 41 unit tests green.