### PR TITLE
feat(issue-12): sheet-compliant 13-column CSV renderer (T2)

### DIFF
--- a/src/serializer/render.ts
+++ b/src/serializer/render.ts
@@ -1,0 +1,170 @@
+/**
+ * SOO-Assigns-Import export-grid renderer — the sheet-compliant CSV artifact.
+ *
+ * Renders a validated plan + resolved boss into the exact 13-column,
+ * per-boss-sectioned CSV the SOO-Assigns-Import tab imports:
+ *
+ *   header row, then all 14 bosses in sheet order, each with a HEALTH %
+ *   template block (15 numbered rows keyed on "Health % (ABBR)", NPC NAME =
+ *   the boss's display name on the first row), a LEAVE BLANK separator, and a
+ *   COUNT block header; assignment rows appear only in the target boss's COUNT
+ *   block, sorted by master event order then TIME.
+ *
+ * Layout notes (observed from the live test sheet, which supersedes the
+ * spec's "blank ×2" wording): column 7 is label-only in data rows, column 8 is
+ * the NPC NAME column (carries scaffold markers), G is the COOLDOWN SPELL
+ * column (the import box is sheet-generated from these rows and is never
+ * written by the app).
+ *
+ * Determinism: stable boss order, master event order, numeric TIME tiebreak,
+ * exact header, no timestamps — identical input yields byte-identical CSV.
+ */
+import * as v from 'valibot';
+import { assignmentSchema } from '../shared/assignments-schema.ts';
+import type { Assignment } from '../shared/assignments-schema.ts';
+import { allSooBosses } from './bosses.ts';
+import type { SooBoss } from './bosses.ts';
+import { validateAssignments } from './validate.ts';
+import type { ValidationIssue } from './validate.ts';
+
+/** The literal emitted in COOLDOWN SPELL for a spell outside the canonical list. */
+export const CUSTOM_SPELL_LITERAL = 'Custom Spell Assignment';
+
+/** The sheet's canonical COOLDOWN SPELL values (docs/tot-assigns-csv-format.md). */
+export const CANONICAL_SPELLS = [
+  'Ancestral Guidance',
+  'Anti-Magic Zone',
+  'Bloodlust',
+  'Demoralizing Banner',
+  'Devotion Aura',
+  'Guardian of Ancient Kings',
+  'Hand of Protection',
+  'Hand of Sacrifice',
+  'Healing Tide Totem',
+  'Pain Suppression',
+  'Power Word: Barrier',
+  'Rallying Cry',
+  'Revival',
+  'Shield Wall',
+  'Smoke Bomb',
+  'Spirit Link Totem',
+  'Spirit Shell',
+  'Stampeding Roar',
+  'Tranquility',
+  'Vampiric Embrace',
+  'Vigilance',
+];
+
+/** HEALTH % template rows per boss (matches the live sheet's 1..15 grid). */
+export const HEALTH_PERCENT_ROWS = 15;
+
+const COL_PLAYER = 0;
+const COL_CD = 1;
+const COL_EVENT = 2;
+const COL_COUNT = 3;
+const COL_ROLE = 4;
+const COL_TIME = 5;
+const COL_SPELL = 6;
+const COL_NPC = 8;
+const COL_ADDITIONAL_TEXT = 9;
+const COL_OVERRIDE_TTS = 10;
+const COL_CUSTOM_NAME = 11;
+const COL_CUSTOM_ICON = 12;
+
+const HEADER = [
+  'Player',
+  'CD #',
+  'BOSS HEALTH / SPELL',
+  'COUNT / HEALTH %',
+  'PLAYER/CLASS/ALL',
+  'TIME',
+  'COOLDOWN SPELL',
+  '',
+  'NPC NAME',
+  'ADDITIONAL TEXT',
+  'OVERRIDE TTS',
+  'CUSTOM NAME',
+  'CUSTOM ICON',
+];
+
+export interface RenderInput {
+  /** The plan (validated inside the renderer). */
+  assignments: unknown;
+  /** The roster role tags (keys of the role mappings) — validation input. */
+  roleMappings?: Record<string, unknown> | null;
+  /** The resolved target boss (from resolveBoss). */
+  boss: SooBoss;
+}
+
+export interface RenderResult {
+  /** The full 13-column CSV artifact, or null when the plan is invalid. */
+  csv: string | null;
+  /** Grouped validation errors (empty when rendered). */
+  errors: ValidationIssue[];
+}
+
+const csvCell = (s: string): string => `"${s.replace(/"/g, '""')}"`;
+const csvLine = (row: string[]): string => row.map(csvCell).join(',');
+
+function bossScaffold(boss: SooBoss): string[][] {
+  const rows: string[][] = [];
+  for (let n = 1; n <= HEALTH_PERCENT_ROWS; n++) {
+    const row = Array<string>(13).fill('');
+    row[COL_CD] = String(n);
+    row[COL_EVENT] = `Health % (${boss.abbr})`;
+    if (n === 1) row[COL_NPC] = boss.wclName;
+    rows.push(row);
+  }
+  const leaveBlank = Array<string>(13).fill('');
+  leaveBlank[COL_NPC] = 'LEAVE BLANK';
+  rows.push(leaveBlank);
+
+  const countHeader = Array<string>(13).fill('');
+  countHeader[COL_COUNT] = 'COUNT';
+  rows.push(countHeader);
+
+  return rows;
+}
+
+function assignmentRow(a: Assignment): string[] {
+  const custom = !CANONICAL_SPELLS.includes(a.spellName);
+  const row = Array<string>(13).fill('');
+  // Player (col A) is left blank — the sheet auto-resolves it from the
+  // role-name bindings (the plan's roleTag already resolves to a player).
+  if (a.cd != null) row[COL_CD] = String(a.cd);
+  row[COL_EVENT] = a.event;
+  row[COL_COUNT] = String(a.occurrence);
+  row[COL_ROLE] = a.roleTag;
+  row[COL_TIME] = String(a.timingOffset);
+  row[COL_SPELL] = custom ? CUSTOM_SPELL_LITERAL : a.spellName;
+  if (a.notes) row[COL_ADDITIONAL_TEXT] = a.notes;
+  // OVERRIDE TTS: an explicit tts override wins; otherwise a custom spell's
+  // real name rides here per the sheet's live convention.
+  row[COL_OVERRIDE_TTS] = custom ? (a.tts || a.spellName) : (a.tts || '');
+  // CUSTOM ICON only for custom rows; blank when the id is unknown.
+  if (custom && a.spellId) row[COL_CUSTOM_ICON] = a.spellId;
+  return row;
+}
+
+export function renderSooAssigns(input: RenderInput): RenderResult {
+  const { assignments, roleMappings, boss } = input;
+
+  const validation = validateAssignments(assignments, { boss, roleMappings });
+  if (!validation.ok) return { csv: null, errors: validation.errors };
+
+  const parsed = v.safeParse(v.array(assignmentSchema), assignments);
+  const plan = parsed.success ? parsed.output : [];
+
+  const rows: string[][] = [HEADER];
+  const eventOrder = boss.events.reduce<Map<string, number>>((m, e, i) => m.set(e, i), new Map());
+  const sorted = [...plan].sort(
+    (a, b) => (eventOrder.get(a.event) ?? 0) - (eventOrder.get(b.event) ?? 0) || a.timingOffset - b.timingOffset,
+  );
+
+  for (const b of allSooBosses()) {
+    rows.push(...bossScaffold(b));
+    if (b.id === boss.id) rows.push(...sorted.map(assignmentRow));
+  }
+
+  return { csv: `${rows.map(csvLine).join('\n')}\n`, errors: [] };
+}

--- a/test/unit/serializer-render.test.ts
+++ b/test/unit/serializer-render.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the SOO-Assigns-Import renderer (T2).
+ *
+ * Pure contract tests: the golden Paragons fixture, per-boss scaffolding,
+ * custom-assignment idiom, determinism, and the validation gate. No env, no
+ * network, no model — runs under `npm test`.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import type { Assignment } from '../../src/shared/assignments-schema.ts';
+import { allSooBosses, resolveBoss } from '../../src/serializer/bosses.ts';
+import { renderSooAssigns, HEALTH_PERCENT_ROWS, CUSTOM_SPELL_LITERAL } from '../../src/serializer/render.ts';
+
+const paragons = resolveBoss('Paragons of the Klaxxi');
+assert.ok(paragons, 'Paragons must resolve for the fixture');
+
+const ROLE_MAPPINGS = {
+  PROTPALA1: { name: 'Paladino' },
+  DISC1: { name: 'Sacred' },
+  RSHAM1: { name: 'Totem' },
+};
+
+/** Representative Paragons plan covering the AC surface. */
+const goldenPlan: Assignment[] = [
+  { event: 'Encounter Start (PAR)', occurrence: 1, roleTag: 'ALL', timingOffset: 0, spellName: 'Bloodlust', notes: '', spellId: '2825' },
+  { event: 'Reave', occurrence: 1, roleTag: 'PROTPALA1', timingOffset: -20, spellName: 'Shield Wall', notes: 'tank external', spellId: '871' },
+  { event: 'Death from Above (PAR)', occurrence: '1,4', roleTag: 'RSHAM1', timingOffset: 0.5, spellName: 'Spirit Link Totem', notes: '', spellId: '98008', tts: 'Pop SLT' },
+  { event: 'Whirling', occurrence: 2, roleTag: 'MELEEDPS', timingOffset: 5, spellName: 'Lay on Hands', notes: 'bop priest', spellId: '633' },
+  // custom spell with an unknown id → blank CUSTOM ICON, never a failed render
+  { event: 'Hurl Amber', occurrence: 3, roleTag: 'PROTPALA1', timingOffset: 10, spellName: 'Void Shift', notes: '', spellId: '' },
+];
+
+/** Expected assignment rows, sorted by master event order then TIME. */
+const goldenBlock = [
+  `"","","Encounter Start (PAR)","1","ALL","0","Bloodlust","","","","","",""`,
+  `"","","Reave","1","PROTPALA1","-20","Shield Wall","","","tank external","","",""`,
+  `"","","Death from Above (PAR)","1,4","RSHAM1","0.5","Spirit Link Totem","","","","Pop SLT","",""`,
+  `"","","Whirling","2","MELEEDPS","5","Custom Spell Assignment","","","bop priest","Lay on Hands","","633"`,
+  `"","","Hurl Amber","3","PROTPALA1","10","Custom Spell Assignment","","","","Void Shift","",""`,
+];
+
+const HEADER = '"Player","CD #","BOSS HEALTH / SPELL","COUNT / HEALTH %","PLAYER/CLASS/ALL","TIME","COOLDOWN SPELL","","NPC NAME","ADDITIONAL TEXT","OVERRIDE TTS","CUSTOM NAME","CUSTOM ICON"';
+const SCAFFOLD_ROWS = HEALTH_PERCENT_ROWS + 2; // 15 HEALTH % rows + LEAVE BLANK + COUNT header
+
+function renderLines(plan: unknown[]): string[] {
+  const r = renderSooAssigns({ assignments: plan, roleMappings: ROLE_MAPPINGS, boss: paragons! });
+  assert.ok(r.csv, `expected a render, got errors: ${JSON.stringify(r.errors)}`);
+  return r.csv.split('\n').filter((l) => l !== '');
+}
+
+/** Line index where the target boss's COUNT-block assignment rows start. */
+function targetBlockStart(lines: string[]): number {
+  const bossIndex = allSooBosses().findIndex((b) => b.id === paragons!.id);
+  return 1 + bossIndex * SCAFFOLD_ROWS + SCAFFOLD_ROWS;
+}
+
+test('T2: header + 14 per-boss scaffolds; assignments only in the target COUNT block', () => {
+  const lines = renderLines(goldenPlan);
+  assert.equal(lines[0], HEADER);
+  // every boss scaffolds HEALTH % ×15 + LEAVE BLANK + COUNT, in sheet order
+  const bosses = allSooBosses();
+  assert.equal(bosses.length, 14);
+  assert.equal(lines.filter((l) => /^"","\d+","Health % \([A-Z]+\)"/.test(l)).length, 14 * HEALTH_PERCENT_ROWS);
+  assert.equal(lines.filter((l) => l.includes('"LEAVE BLANK"')).length, 14);
+  assert.equal(lines.filter((l) => l.includes('"","","","COUNT",""')).length, 14);
+  // first scaffold row carries the boss display name in the NPC column
+  assert.equal(lines[1], `"","1","Health % (IMM)","","","","","","Immerseus","","","",""`);
+  assert.equal(lines[2], `"","2","Health % (IMM)","","","","","","","","","",""`);
+  // the target boss's first scaffold row at its sheet-order offset
+  const parStart = 1 + allSooBosses().findIndex((b) => b.id === paragons!.id) * SCAFFOLD_ROWS;
+  assert.equal(lines[parStart], `"","1","Health % (PAR)","","","","","","Paragons of the Klaxxi","","","",""`);
+  // total lines = header + 14 scaffolds (+ assignments)
+  assert.equal(lines.length, 1 + 14 * SCAFFOLD_ROWS + goldenBlock.length);
+});
+
+test('T2: golden Paragons block — exact 13-column rows, sorted, custom idiom, byte-identical on re-run', () => {
+  const r1 = renderSooAssigns({ assignments: goldenPlan, roleMappings: ROLE_MAPPINGS, boss: paragons! });
+  const r2 = renderSooAssigns({ assignments: goldenPlan, roleMappings: ROLE_MAPPINGS, boss: paragons! });
+  assert.equal(r2.csv, r1.csv, 'reruns must be byte-identical');
+  const lines = r1.csv!.split('\n').filter((l) => l !== '');
+  const start = targetBlockStart(lines);
+  assert.deepEqual(lines.slice(start, start + goldenBlock.length), goldenBlock);
+});
+
+test('T2: an off-vocabulary event never renders — grouped validation errors instead', () => {
+  const bad = [{ ...goldenPlan[0], event: 'Calamity' }];
+  const r = renderSooAssigns({ assignments: bad, roleMappings: ROLE_MAPPINGS, boss: paragons! });
+  assert.equal(r.csv, null);
+  assert.ok(r.errors.some((e) => e.field === 'event' && /Calamity/.test(e.message)));
+});
+
+test('T2: an empty plan renders scaffolding-only output (no assignment rows, still valid)', () => {
+  const lines = renderLines([]);
+  assert.equal(lines.length, 1 + 14 * SCAFFOLD_ROWS);
+  // nothing after Paragons' COUNT header except Paragons' own scaffold is intact
+  const start = targetBlockStart(lines);
+  assert.equal(lines[start], `"","1","Health % (GAR)","","","","","","Garrosh Hellscream","","","",""`); // next boss scaffold
+});
+
+test('T2: canonical spells emit a plain row; custom spells use the literal + OVERRIDE TTS + icon', () => {
+  const canonicalRows = renderLines(goldenPlan).filter((l) => l.includes('"Bloodlust"'));
+  assert.equal(canonicalRows.length, 1);
+  assert.equal(CUSTOM_SPELL_LITERAL, 'Custom Spell Assignment');
+  const customRows = renderLines(goldenPlan).filter((l) => l.includes(CUSTOM_SPELL_LITERAL));
+  assert.equal(customRows.length, 2);
+});
+
+test('T2: timing formats preserve negatives and fractions; occurrence keeps comma-lists', () => {
+  const lines = renderLines(goldenPlan);
+  const block = lines.slice(targetBlockStart(lines), targetBlockStart(lines) + goldenBlock.length);
+  assert.ok(block.some((l) => l.includes('"-20"')));
+  assert.ok(block.some((l) => l.includes('"0.5"')));
+  assert.ok(block.some((l) => l.includes('"1,4"')));
+  assert.ok(block.some((l) => l.includes('"0"')));
+});


### PR DESCRIPTION
Renders the sheet-compliant SOO-Assigns-Import artifact from a validated plan + resolved boss.

- **Scaffold** (from the live test-sheet layout): 15 HEALTH % rows per boss (B=1..15, `Health % (ABBR)`, NPC NAME = boss display name on row 1), LEAVE BLANK separator, COUNT block header — every boss, in sheet order.
- **Assignments** only in the target boss's COUNT block, sorted by master event order then TIME; Player left blank (sheet auto-resolves).
- **Custom idiom**: `CUSTOM_SPELL_LITERAL` + real spell in OVERRIDE TTS, id in CUSTOM ICON, blank icon when the id is unknown.
- **Determinism**: all-quoted CSV (matches the live sheet's export style), byte-identical reruns — golden Paragons block asserted in tests.
- `CANONICAL_SPELLS` (21 spells from the format doc) + `CUSTOM_SPELL_LITERAL` exported for the CLI wiring ticket.

Layout note recorded: the spec's 'blank ×2' columns are superseded by the live sheet (col H is label-only in data rows, col I is the NPC NAME column). 6 new tests; 47 unit tests green.