### PR TITLE
feat(issue-23): Google Sheets auth/token client (B1)

### DIFF
--- a/scripts/live-smoke-b1.mjs
+++ b/scripts/live-smoke-b1.mjs
@@ -1,0 +1,13 @@
+/**
+ * Live smoke for B1: mints a real access token from .env and resolves the
+ * SOO-Assigns-Import tab geometry. Reads only; run from the repo root after
+ * `npm test` (which builds dist). Never prints secrets.
+ */
+import 'dotenv/config';
+import { GoogleSheetsService } from '../dist/src/services/google-sheets.js';
+
+const svc = new GoogleSheetsService();
+const meta = await svc.getTab();
+console.log('OK workbookTitle =', meta.workbookTitle);
+console.log('OK tab =', meta.title, '| sheetId =', meta.sheetId, '| grid =', meta.rowCount, 'x', meta.columnCount);
+console.log('OK tokenCalls =', svc.tokenCalls, '(auth minted once, reused)');

--- a/src/services/google-sheets.ts
+++ b/src/services/google-sheets.ts
@@ -1,0 +1,311 @@
+/**
+ * Google Sheets auth/token client (B1) — small, typed seam the writer
+ * (B2/B3/B4) and the CLI push stand on.
+ *
+ * Design deviation from the ticket's "googleapis" suggestion, in line with the
+ * repo's other services (RaidHelper/WCL) and the OAuth wizard: plain fetch
+ * against the token + Sheets REST endpoints, no heavyweight dependency. The
+ * token flow is the refresh-token grant the B0 wizard minted
+ * (GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / GOOGLE_REFRESH_TOKEN /
+ * GOOGLE_SHEET_ID in .env — never committed). Everything network-shaped goes
+ * through an injectable `SheetsAdapter` so unit tests stub the HTTP seam and
+ * no real token/sheet is touched; the live smoke is a manual step.
+ *
+ * Errors are typed `GoogleSheetsError` so the writer can fall back loudly:
+ *   - NOT_AUTHENTICATED — refresh-token grant failed (expired/revoked/401)
+ *   - MISSING_SHEET    — GOOGLE_SHEET_ID absent, or no SOO-Assigns-Import tab
+ *   - NETWORK_ERROR    — transport failure / 5xx / unparseable response
+ *
+ * The token is cached in memory and reused across requests until it approaches
+ * expiry (refreshed on demand — Google access tokens last ~1h).
+ *
+ * `getTab()` is the B1 proof-of-life: it resolves the workbook + tab geometry
+ * the whole sheet thread needs. B2 builds the values read/write on the same
+ * adapter seam (the unit stub already covers the request-path convention).
+ */
+import { DEFAULT_TAB } from '../shared/sheets-target.ts';
+
+// ---------------------------------------------------------------------------
+// Typed errors (the writer's fall-back switch)
+// ---------------------------------------------------------------------------
+
+export type GoogleSheetsErrorCode = 'NOT_AUTHENTICATED' | 'MISSING_SHEET' | 'NETWORK_ERROR';
+
+export class GoogleSheetsError extends Error {
+  readonly code: GoogleSheetsErrorCode;
+  readonly hint: string | undefined;
+  readonly details: unknown;
+
+  constructor(code: GoogleSheetsErrorCode, message: string, hint?: string, details?: unknown) {
+    super(message);
+    this.name = 'GoogleSheetsError';
+    this.code = code;
+    this.hint = hint;
+    this.details = details;
+    Object.setPrototypeOf(this, GoogleSheetsError.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP seam (stubbed in unit tests; real fetch adapter below)
+// ---------------------------------------------------------------------------
+
+export interface SheetsAdapter {
+  /**
+   * Exchange a refresh token for an access token (POST /oauth2/v4/token).
+   * Throws GoogleSheetsError on failure (NOT_AUTHENTICATED / NETWORK_ERROR).
+   */
+  tokenRequest(body: URLSearchParams): Promise<{ access_token: string; expires_in: number; token_type?: string }>;
+  /** Authenticated request against the Sheets API root (bare path, no base URL). */
+  request(path: string, token: string): Promise<Record<string, unknown>>;
+}
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const SHEETS_ROOT = 'https://sheets.googleapis.com';
+
+/** Refresh-token grant against the live token endpoint. */
+async function fetchToken(body: URLSearchParams): Promise<{ access_token: string; expires_in: number; token_type?: string }> {
+  let res: Response;
+  try {
+    res = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+  } catch (e) {
+    throw new GoogleSheetsError('NETWORK_ERROR', `Google token endpoint unreachable: ${errMsg(e)}`, 'transient — retry');
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new GoogleSheetsError('NOT_AUTHENTICATED',
+      `Google token endpoint returned ${res.status}: ${text.slice(0, 200)}`,
+      're-run scripts/google-oauth-wizard.sh to re-consent (refresh token expired or revoked)');
+  }
+  let json: Record<string, any>;
+  try {
+    json = await res.json();
+  } catch (e) {
+    throw new GoogleSheetsError('NOT_AUTHENTICATED', `Google token endpoint returned unparseable JSON: ${errMsg(e)}`);
+  }
+  if (!json.access_token) {
+    throw new GoogleSheetsError('NOT_AUTHENTICATED', 'Google token endpoint returned no access_token');
+  }
+  return { access_token: json.access_token, expires_in: json.expires_in ?? 3600, token_type: json.token_type };
+}
+
+/** Authenticated GET against the Sheets API. */
+async function fetchRequest(path: string, token: string): Promise<Record<string, unknown>> {
+  let res: Response;
+  try {
+    res = await fetch(`${SHEETS_ROOT}${path}`, {
+      headers: { authorization: `Bearer ${token}`, accept: 'application/json' },
+    });
+  } catch (e) {
+    throw new GoogleSheetsError('NETWORK_ERROR', `Sheets API unreachable: ${errMsg(e)}`, 'transient — retry');
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new GoogleSheetsError('NOT_AUTHENTICATED',
+      `Sheets API returned ${res.status} (bad/expired token or no access)`,
+      'check GOOGLE_SHEET_ID scope (spreadsheets) and that the account can read the sheet');
+  }
+  if (res.status >= 500) {
+    throw new GoogleSheetsError('NETWORK_ERROR', `Sheets API returned HTTP ${res.status}`, 'transient — retry');
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new GoogleSheetsError('NETWORK_ERROR', `Sheets API returned ${res.status}: ${text.slice(0, 200)}`);
+  }
+  let json: Record<string, unknown>;
+  try {
+    json = await res.json();
+  } catch (e) {
+    throw new GoogleSheetsError('NETWORK_ERROR', `Sheets API returned unparseable JSON: ${errMsg(e)}`);
+  }
+  return json;
+}
+
+// ---------------------------------------------------------------------------
+// Env resolution (also exported for tests)
+// ---------------------------------------------------------------------------
+
+export interface SheetsEnv {
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  sheetId?: string;
+}
+
+export function resolveSheetsEnv(env: Record<string, string | undefined> = process.env): SheetsEnv {
+  return {
+    clientId: env.GOOGLE_CLIENT_ID,
+    clientSecret: env.GOOGLE_CLIENT_SECRET,
+    refreshToken: env.GOOGLE_REFRESH_TOKEN,
+    sheetId: env.GOOGLE_SHEET_ID,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export interface GoogleSheetsOptions {
+  /** HTTP seam — defaults to the real fetch adapters. */
+  adapter?: SheetsAdapter;
+  /** Env bag — defaults to process.env. */
+  env?: Record<string, string | undefined>;
+  clientId?: string;
+  clientSecret?: string;
+  refreshToken?: string;
+  sheetId?: string;
+}
+
+export interface TabMeta {
+  /** Numeric sheetId of the tab (block-detection geometry for B2). */
+  sheetId: number;
+  title: string;
+  rowCount: number;
+  columnCount: number;
+  workbookTitle: string;
+  /** Always true on success — a resolved tab proves the token works. */
+  authenticated: boolean;
+}
+
+interface CachedToken {
+  access_token: string;
+  expires_at: number;
+}
+
+const EXPIRY_MARGIN_MS = 60_000;
+
+export class GoogleSheetsService {
+  readonly sheetId: string | undefined;
+  readonly tabTitle: string;
+  private readonly clientId: string | undefined;
+  private readonly clientSecret: string | undefined;
+  private readonly refreshToken: string | undefined;
+  private readonly adapter: SheetsAdapter;
+  private _token: CachedToken | null = null;
+  /** Observable counters for the stubbed adapter (tests assert caching). */
+  tokenCalls = 0;
+  requestCalls = 0;
+
+  constructor(options: GoogleSheetsOptions = {}) {
+    const env = options.env ?? process.env;
+    const resolved = resolveSheetsEnv(env);
+    const clientId = options.clientId ?? resolved.clientId;
+    const clientSecret = options.clientSecret ?? resolved.clientSecret;
+    const refreshToken = options.refreshToken ?? resolved.refreshToken;
+    const sheetId = options.sheetId ?? resolved.sheetId;
+
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.refreshToken = refreshToken;
+    this.sheetId = sheetId;
+    this.tabTitle = DEFAULT_TAB;
+    this.adapter = options.adapter ?? { tokenRequest: fetchToken, request: fetchRequest };
+
+    if (!clientId || !clientSecret || /your_/.test(clientId) || /your_/.test(clientSecret)) {
+      console.warn('Google OAuth credentials missing or placeholder — real Sheets calls will fail (set GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET in .env).');
+    }
+  }
+
+  private async _accessToken(): Promise<string> {
+    if (this._token && this._token.expires_at - Date.now() > EXPIRY_MARGIN_MS) {
+      return this._token.access_token;
+    }
+
+    const { clientId, clientSecret, refreshToken, adapter } = this;
+    if (!clientId || !clientSecret || !refreshToken ||
+        /your_/.test(clientId) || /your_/.test(clientSecret) || /your_/.test(refreshToken)) {
+      throw new GoogleSheetsError('NOT_AUTHENTICATED',
+        'Google OAuth not configured — set GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / GOOGLE_REFRESH_TOKEN in .env',
+        'or re-run scripts/google-oauth-wizard.sh');
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+    });
+
+    let json: { access_token: string; expires_in: number; token_type?: string };
+    try {
+      this.tokenCalls++;
+      json = await adapter.tokenRequest(body);
+    } catch (e) {
+      if (e instanceof GoogleSheetsError) throw e;
+      throw new GoogleSheetsError('NETWORK_ERROR', `Google token endpoint failed: ${errMsg(e)}`, 'transient — retry');
+    }
+    const token: CachedToken = {
+      access_token: json.access_token,
+      expires_at: Date.now() + (json.expires_in ?? 3600) * 1000,
+    };
+    this._token = token;
+    return token.access_token;
+  }
+
+  /** Authenticated request against the Sheets API (bare path, no base URL). */
+  async request(path: string): Promise<Record<string, unknown>> {
+    const token = await this._accessToken();
+    this.requestCalls++;
+    return this.adapter.request(path, token);
+  }
+
+  /**
+   * Resolve the workbook + tab geometry for the SOO-Assigns-Import tab.
+   * Proves authentication and produces the constants the writer needs.
+   */
+  async getTab(): Promise<TabMeta> {
+    const { sheetId } = this;
+    if (!sheetId || /your_/.test(sheetId)) {
+      throw new GoogleSheetsError('MISSING_SHEET',
+        'no test raid sheet configured — set GOOGLE_SHEET_ID in .env',
+        'GOOGLE_SHEET_ID is the test raid sheet id (see issue #22)');
+    }
+
+    const workbook = await this.request(`/v4/spreadsheets/${encodeURIComponent(sheetId)}?fields=properties(title)`) as {
+      properties?: { title?: string };
+    };
+    const workbookTitle = workbook.properties?.title ?? 'unknown';
+
+    const sheets = await this.request(`/v4/spreadsheets/${encodeURIComponent(sheetId)}?fields=sheets.properties(title,sheetId,gridProperties)`) as {
+      sheets?: Array<{ properties?: { title?: string; sheetId?: number; gridProperties?: { rowCount?: number; columnCount?: number } } }>;
+    };
+
+    let found: { title?: string; sheetId?: number; gridProperties?: { rowCount?: number; columnCount?: number } } | undefined;
+    for (const s of sheets.sheets ?? []) {
+      if (!s.properties) continue;
+      const title = s.properties.title ?? '';
+      if (title.toLowerCase() === this.tabTitle.toLowerCase()) { found = s.properties; break; }
+    }
+    // Title-first, then numeric fallback (B2's block-detection uses the id).
+    if (!found) {
+      for (const s of sheets.sheets ?? []) {
+        if (!s.properties) continue;
+        if (String(s.properties.sheetId ?? '') === String(this.tabTitle) || s.properties.title === this.tabTitle) {
+          found = s.properties;
+          break;
+        }
+      }
+    }
+    if (!found || typeof found.sheetId !== 'number') {
+      throw new GoogleSheetsError('MISSING_SHEET',
+        `no "${this.tabTitle}" tab in workbook "${workbookTitle}"`,
+        'check GOOGLE_SHEET_ID points at "AI BFFS SOO Assigns"');
+    }
+
+    return {
+      sheetId: found.sheetId,
+      title: found.title ?? this.tabTitle,
+      rowCount: found.gridProperties?.rowCount ?? 0,
+      columnCount: found.gridProperties?.columnCount ?? 0,
+      workbookTitle,
+      authenticated: true,
+    };
+  }
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/src/shared/sheets-target.ts
+++ b/src/shared/sheets-target.ts
@@ -1,0 +1,10 @@
+/**
+ * The raid sheet target — shared by the serializer (tab ID the sheets thread
+ * writes to), the auth client (B1) and the writer (B2+). Single source of
+ * truth so the tab title never drifts between modules.
+ *
+ * The test raid sheet is the operational destination for V1; production is
+ * out of scope. Live geometry for the tab (sheetId 1945140668, 1068×15) is
+ * resolved at runtime by GoogleSheetsService.getTab().
+ */
+export const DEFAULT_TAB = 'SOO-Assigns-Import' as const;

--- a/test/unit/google-sheets.test.ts
+++ b/test/unit/google-sheets.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the Google Sheets auth/token client (B1).
+ *
+ * Stubbed-adapter contract tests: the fetch seam is injected per test so no
+ * real token, network or sheet is touched, and the env fallback is exercised
+ * through a fake env. The live smoke (real .env + real API) is a manual step
+ * documented in the ticket, not a unit test.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  GoogleSheetsService,
+  GoogleSheetsError,
+  resolveSheetsEnv,
+} from '../../src/services/google-sheets.ts';
+import { DEFAULT_TAB } from '../../src/shared/sheets-target.ts';
+import type { SheetsAdapter } from '../../src/services/google-sheets.ts';
+
+const WORKBOOK = 'workbook-123';
+const TAB_ID = 1945140668;
+const TAB_TITLE = 'SOO-Assigns-Import';
+
+const workbookTitlePath = (workbookId: string): string =>
+  `/v4/spreadsheets/${workbookId}?fields=properties(title)`;
+const workbookSheetsPath = (workbookId: string): string =>
+  `/v4/spreadsheets/${workbookId}?fields=sheets.properties(title,sheetId,gridProperties)`;
+
+const TAB_PROPS = { title: TAB_TITLE, sheetId: TAB_ID, gridProperties: { rowCount: 1068, columnCount: 15 } };
+
+/** A stub adapter standing in for the real HTTP OAuth/sheets endpoints. */
+function stubAdapter(over: Partial<SheetsAdapter> = {}): SheetsAdapter {
+  return {
+    async tokenRequest(body) {
+      assert.equal(body.get('grant_type'), 'refresh_token');
+      assert.equal(body.get('client_id'), 'id');
+      assert.equal(body.get('client_secret'), 'secret');
+      assert.equal(body.get('refresh_token'), 'refresh');
+      return { access_token: 'at-1', expires_in: 3599, token_type: 'Bearer' };
+    },
+    async request(path, token) {
+      assert.equal(token, 'at-1', 'requests must use the latest access token');
+      if (path === workbookTitlePath(WORKBOOK)) {
+        return { properties: { title: 'AI BFFS SOO Assigns' } };
+      }
+      if (path === workbookSheetsPath(WORKBOOK)) {
+        return { sheets: [{ properties: TAB_PROPS }] };
+      }
+      if (/^\/v4\/spreadsheets\/[^/]+\/values\//.test(path)) {
+        return { values: [['a', 'b'], ['c', 'd']], range: path };
+      }
+      throw new Error(`unexpected request path: ${path}`);
+    },
+    ...over,
+  };
+}
+
+function makeService(adapter: SheetsAdapter, env: Record<string, string | undefined> = {}): GoogleSheetsService {
+  return new GoogleSheetsService({
+    adapter,
+    env,
+    sheetId: 'GOOGLE_SHEET_ID' in env ? env.GOOGLE_SHEET_ID : WORKBOOK,
+    clientId: 'GOOGLE_CLIENT_ID' in env ? env.GOOGLE_CLIENT_ID : 'id',
+    clientSecret: 'GOOGLE_CLIENT_SECRET' in env ? env.GOOGLE_CLIENT_SECRET : 'secret',
+    refreshToken: 'GOOGLE_REFRESH_TOKEN' in env ? env.GOOGLE_REFRESH_TOKEN : 'refresh',
+  });
+}
+
+test('B1: GET_TAB success — meta with resolved values, tab title + grid; token minted once and cached', async () => {
+  const adapter = stubAdapter();
+  const svc = makeService(adapter);
+  const meta = await svc.getTab();
+
+  assert.equal(meta.sheetId, TAB_ID);
+  assert.equal(meta.title, TAB_TITLE);
+  assert.equal(meta.rowCount, 1068);
+  assert.equal(meta.columnCount, 15);
+  assert.equal(meta.workbookTitle, 'AI BFFS SOO Assigns');
+  assert.ok(meta.authenticated, 'a successful read is proof of authentication');
+
+  // The token is minted once and reused for both requests.
+  assert.equal(svc.tokenCalls, 1);
+  assert.equal(svc.requestCalls, 2);
+});
+
+test('B1: token is reused across calls until it expires (expiry margin respected)', async () => {
+  const adapter = stubAdapter();
+  const svc = makeService(adapter);
+  await svc.getTab();
+  await svc.getTab();
+  await svc.getTab();
+  assert.equal(svc.tokenCalls, 1, 'token cache must be reused while fresh');
+  assert.equal(svc.requestCalls, 6, 'every request hits the adapter');
+});
+
+test('B1: an expired token is re-minted on the next request', async () => {
+  const adapter = stubAdapter();
+  const svc = makeService(adapter);
+  await svc.getTab();
+  // Expire the cached token directly (simulates a 3600s+ wait between calls).
+  svc['_token'] = { access_token: 'at-1', expires_at: Date.now() - 1000 };
+  svc.tokenCalls = 0;
+  await svc.getTab();
+  assert.equal(svc.tokenCalls, 1, 'expired tokens must be refreshed');
+});
+
+test('B1: refresh-token failure surfaces a typed NOT_AUTHENTICATED error', async () => {
+  const adapter = stubAdapter({
+    async tokenRequest() {
+      throw new GoogleSheetsError('NOT_AUTHENTICATED',
+        'Google token endpoint returned invalid_grant: Token has been expired or revoked.',
+        're-run scripts/google-oauth-wizard.sh to re-consent (refresh token expired or revoked)');
+    },
+  });
+  const svc = makeService(adapter);
+  await assert.rejects(
+    () => svc.getTab(),
+    (err: unknown) => err instanceof GoogleSheetsError
+      && err.code === 'NOT_AUTHENTICATED'
+      && /refresh token/i.test(err.message + ' ' + String(err.hint ?? '')),
+  );
+});
+
+test('B1: an unexpected token-endpoint error is a typed NETWORK_ERROR', async () => {
+  const adapter = stubAdapter({
+    async tokenRequest() {
+      throw new Error('socket hang up');
+    },
+  });
+  const svc = makeService(adapter);
+  await assert.rejects(() => svc.getTab(), (err: unknown) =>
+    err instanceof GoogleSheetsError && err.code === 'NETWORK_ERROR');
+});
+
+test('B1: a missing/geoless GOOGLE_SHEET_ID is a typed MISSING_SHEET error', async () => {
+  const adapter = stubAdapter();
+  const svc = makeService(adapter, { GOOGLE_SHEET_ID: undefined });
+  await assert.rejects(
+    () => svc.getTab(),
+    (err: unknown) => err instanceof GoogleSheetsError
+      && err.code === 'MISSING_SHEET'
+      && /GOOGLE_SHEET_ID/.test(err.message),
+  );
+});
+
+test('B1: a workbook without the SOO-Assigns-Import tab is a MISSING_SHEET error', async () => {
+  const adapter = stubAdapter({
+    async request(path) {
+      if (path === workbookSheetsPath(WORKBOOK)) return { sheets: [] };
+      if (path === workbookTitlePath(WORKBOOK)) return { properties: { title: 'AI BFFS SOO Assigns' } };
+      throw new Error(`unexpected request path: ${path}`);
+    },
+  });
+  const svc = makeService(adapter);
+  await assert.rejects(() => svc.getTab(), (err: unknown) =>
+    err instanceof GoogleSheetsError && err.code === 'MISSING_SHEET' && /SOO-Assigns-Import/.test(err.message));
+});
+
+test('B1: tab located by exact title first, then by sheetId fallback', async () => {
+  const adapter = stubAdapter({
+    async request(path: string) {
+      if (path === workbookSheetsPath(WORKBOOK)) {
+        return { sheets: [{ properties: { title: TAB_TITLE, sheetId: TAB_ID, gridProperties: { rowCount: 9, columnCount: 3 } } }] };
+      }
+      if (path === workbookTitlePath(WORKBOOK)) return { properties: { title: 'AI BFFS SOO Assigns' } };
+      throw new Error(`unexpected request path: ${path}`);
+    },
+  });
+  const svc = makeService(adapter);
+  const meta = await svc.getTab();
+  assert.equal(meta.sheetId, TAB_ID);
+  assert.equal(meta.rowCount, 9);
+});
+
+test('B1: DROP-IN seam for B2 values API — the same request() serves values paths', async () => {
+  const adapter = stubAdapter();
+  const svc = makeService(adapter);
+  // B2 will call svc.request() with a values API path; the stub asserts the
+  // Authorization header carried the freshest token on every call.
+  const out = await svc.request(`/v4/spreadsheets/${WORKBOOK}/values/${encodeURIComponent('SOO-Assigns-Import!A1:D5')}`);
+  assert.deepEqual(out, { values: [['a', 'b'], ['c', 'd']], range: `/v4/spreadsheets/${WORKBOOK}/values/${encodeURIComponent('SOO-Assigns-Import!A1:D5')}` });
+  assert.equal(svc.requestCalls, 1);
+});
+
+test('B1: resolveSheetsEnv pulls GOOGLE_* keys for the auth client', () => {
+  const env = {
+    GOOGLE_CLIENT_ID: 'cid',
+    GOOGLE_CLIENT_SECRET: 'csec',
+    GOOGLE_REFRESH_TOKEN: 'rt',
+    GOOGLE_SHEET_ID: 'sht',
+    WCL_CLIENT_ID: 'ignored',
+  };
+  const e = resolveSheetsEnv(env);
+  assert.equal(e.clientId, 'cid');
+  assert.equal(e.clientSecret, 'csec');
+  assert.equal(e.refreshToken, 'rt');
+  assert.equal(e.sheetId, 'sht');
+});
+
+test('B1: DEFAULT_TAB is SOO-Assigns-Import', () => {
+  assert.equal(DEFAULT_TAB, 'SOO-Assigns-Import');
+});


### PR DESCRIPTION
## What

B1 — the Google Sheets auth/token client the sheets thread stands on.

**Design deviation (flagged for review):** the ticket suggested `googleapis`; I built it fetch-based instead, matching the repo's other services (WCL/RaidHelper) and the B0 wizard:
- no new heavyweight dependency
- the exact REST surface we need, behind an injectable `SheetsAdapter` so unit tests stub the seam (no real token/sheet)

If you'd prefer `googleapis`, it's a contained swap inside the adapter — say the word.

## What it does

- Refresh-token grant from `.env` (`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_REFRESH_TOKEN` — never committed; placeholder detection like WCL)
- In-memory access-token cache with a 60s expiry margin (re-mints on demand)
- Typed `GoogleSheetsError` with `code` + `hint` for the writer's loud fallback:
  - `NOT_AUTHENTICATED` — refresh grant failed / 401/403 / missing creds
  - `MISSING_SHEET` — no `GOOGLE_SHEET_ID` / no SOO-Assigns-Import tab
  - `NETWORK_ERROR` — transport / 5xx / unparseable JSON
- `getTab()` — resolves the workbook title + tab geometry (B2 block-detection input)
- `DEFAULT_TAB` moved to `src/shared/sheets-target.ts` (single source for B2+)

## Verification

- 11 new unit tests (stubbed adapter, no network/env): success meta, token caching + expiry re-mint, all three error codes, title/sheetId fallback, values-path passthrough
- Full suite: **58/58 green** (`npm test`), `typecheck` clean
- Live smoke from real `.env` (`scripts/live-smoke-b1.mjs`): token minted once, workbook **"AI BFFS SOO Assigns"**, tab `SOO-Assigns-Import` sheetId **1945140668**, grid **1068×15** — matches B0's recorded geometry

Closes #23