### PR TITLE
C0: raid-night CLI — report-optional generation + explicit --raidhelper-event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .cache/
 backups/
 dist/backups/
+dist/

--- a/src/agents/assignment-generator.ts
+++ b/src/agents/assignment-generator.ts
@@ -39,6 +39,10 @@ export function AssignmentGenerator() {
     ? `Community Practices (Highly Recommended Strategy to Mimic):\n${communityStrategy}`
     : '(No community strategy was provided for this encounter.)';
 
+  const timelineSection = timeline?.length
+    ? JSON.stringify(timeline)
+    : '(No encounter timeline was provided — plan from the encounter’s standard SOO boss events (e.g. “Encounter Start”, the boss’s signature heavy-hitting events) and the raid roster below.)';
+
   return `You are an expert World of Warcraft: Mists of Pandaria raid leader.
 Your task is to assign raid cooldowns to major boss events based on the provided encounter timeline and the available raid roster.
 
@@ -49,7 +53,7 @@ Current Raid Roster Roles Available:
 ${JSON.stringify(Object.keys(roleMappings))}
 
 Encounter Timeline:
-${JSON.stringify(timeline, null, 2)}
+${timelineSection}
 
 ${strategySection}
 
@@ -66,7 +70,7 @@ When the full assignment matrix is ready, call submit_assignments once with { as
 }
 
 AssignmentGenerator.initialData = v.object({
-  timeline: v.array(v.unknown()),
+  timeline: v.optional(v.array(v.unknown())),
   roleMappings: v.record(v.string(), v.unknown()),
   skillsData: v.unknown(),
   communityStrategy: v.string(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,10 @@ function stateOption(): Option {
   return new Option('--state <dir>', 'state directory for artifacts (default: .cache/cli)');
 }
 
+function raidhelperEventOption(): Option {
+  return new Option('-R, --raidhelper-event <id>', 'RaidHelper event id for the roster (no WCL report needed)');
+}
+
 export function createProgram(handlers: Handlers): Command {
   const program = new Command();
   program
@@ -74,7 +78,8 @@ export function createProgram(handlers: Handlers): Command {
   program
     .command('mappings')
     .description('Fetch the RaidHelper role mappings for an encounter into state')
-    .requiredOption('-e, --encounter <name|id>', 'Encounter name or id for community pulls')
+    .option('-e, --encounter <name|id>', 'Encounter name or id for community pulls')
+    .addOption(raidhelperEventOption())
     .addOption(stateOption())
     .action((opts) => handlers.mappings(opts));
 
@@ -82,21 +87,25 @@ export function createProgram(handlers: Handlers): Command {
     .command('community')
     .description('Fetch community pulls and analyse the strategy into state')
     .requiredOption('-e, --encounter <name|id>', 'Encounter name or id for community pulls')
+    .addOption(raidhelperEventOption())
     .addOption(instanceOption())
     .addOption(stateOption())
     .action((opts) => handlers.community(opts));
 
   program
     .command('generate')
-    .description('Generate assignments from the artifacts in state')
+    .description('Generate assignments from the artifacts in state (no WCL report needed)')
+    .option('-e, --encounter <name|id>', 'Encounter name or id (for boss resolution / the sheet push)')
+    .addOption(raidhelperEventOption())
     .addOption(stateOption())
     .action((opts) => handlers.generate(opts));
 
   program
     .command('run')
-    .description('Full pipeline: mappings + timeline + community + generate')
-    .option('-r, --report <code>', 'Warcraft Logs report code (prompted if missing)')
-    .option('-f, --fight <id>', 'Fight ID within the report (prompted if missing)', parseFightId)
+    .description('Full pipeline: mappings + (timeline) + community + generate')
+    .option('-r, --report <code>', 'Warcraft Logs report code (optional — generation can run from the roster alone)')
+    .option('-f, --fight <id>', 'Fight ID within the report (only with -r)', parseFightId)
+    .option('-R, --raidhelper-event <id>', 'RaidHelper event id for the roster (no WCL report needed)')
     .option('-e, --encounter <name|id>', 'Encounter name or id (prompted if missing)')
     .addOption(instanceOption())
     .addOption(stateOption())

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,10 +84,12 @@ function communityRanks(): { rankStart: number | null; rankEnd: number | null } 
 // ---------------------------------------------------------------------------
 // Artifact-producing steps (shared by subcommands, `run` and the bare menu)
 // ---------------------------------------------------------------------------
-async function stepMappings(opts: { encounter?: string; state?: string }): Promise<RoleMappings> {
+async function stepMappings(opts: { encounter?: string; raidhelperEvent?: string; state?: string }): Promise<RoleMappings> {
   const { encounter, state } = opts;
-  const rosterEventId = encounter || process.env.RAID_HELPER_EVENT_ID;
-  if (!rosterEventId) throw new Error('no RaidHelper event id — pass -e or set RAID_HELPER_EVENT_ID');
+  // Precedence: explicit -R > RAID_HELPER_EVENT_ID env > prompt (the menu).
+  // An encounter NAME (-e) is never interpreted as a RaidHelper event id.
+  const rosterEventId = opts.raidhelperEvent ?? process.env.RAID_HELPER_EVENT_ID ?? null;
+  if (!rosterEventId) throw new Error('no RaidHelper event id — pass -R/--raidhelper-event or set RAID_HELPER_EVENT_ID');
   const roster = await rhService().getEventRoster(rosterEventId);
   const { mappings, unmapped } = resolveRoleMappings(roster);
   writeJSON(resolveState(state), 'rolemappings.json', { eventId: rosterEventId, mappings, roster });
@@ -131,14 +133,21 @@ async function stepCommunity(opts: { encounter?: string; instance?: string; stat
   return reply.text;
 }
 
-async function stepGenerate(opts: { state?: string; encounter?: string }, { initial = null }: { initial?: unknown } = {}): Promise<Assignment[]> {
+async function stepGenerate(opts: { state?: string; encounter?: string; raidhelperEvent?: string }, { initial = null }: { initial?: unknown } = {}): Promise<Assignment[]> {
   const dir = resolveState(opts.state);
-  const roleMappings = readJSON(dir, 'rolemappings.json')?.mappings ?? {};
+  // RaidHelper roster is the only hard requirement for generation. If no
+  // rolemappings are in state yet, build them from -R/--raidhelper-event
+  // (or RAID_HELPER_EVENT_ID env) on the spot — report/fight are optional.
+  let roleMappings = readJSON(dir, 'rolemappings.json')?.mappings ?? {};
+  if (!Object.keys(roleMappings).length) {
+    const rosterEventId = opts.raidhelperEvent ?? process.env.RAID_HELPER_EVENT_ID;
+    if (!rosterEventId) throw new Error('no rolemappings — run `mappings -R <raidhelper event>` first, or pass -R here');
+    roleMappings = await stepMappings({ raidhelperEvent: rosterEventId, state: opts.state });
+  }
   const timeline = readJSON(dir, 'timeline.json')?.timeline ?? null;
   const community = readJSON(dir, 'community.json');
   const resolvedEncounter = opts.encounter ?? process.env.RAID_HELPER_ENCOUNTER ?? '';
-  if (!Object.keys(roleMappings).length) throw new Error('no rolemappings — run `mappings` first');
-  if (!timeline) throw new Error('no timeline — run `timeline` first');
+  if (!timeline) console.warn('[generate] no timeline in state — refining from the roster/community only (report lane is optional)');
 
   const skillsData = JSON.parse(fs.readFileSync(new URL('../src/data/mop_skills.json', import.meta.url), 'utf8'));
   const generator = init(AssignmentGenerator, { id: `generate-${Date.now()}` });
@@ -263,22 +272,23 @@ function errMsg(e: unknown): string {
 // CLI handlers (createProgram contracts)
 // ---------------------------------------------------------------------------
 const handlers: Handlers = {
-  mappings: async (opts: CliOptions) => { try { await stepMappings({ encounter: opts.encounter, state: opts.state }); } catch (e) { console.error('mappings failed:', errMsg(e)); process.exitCode = 1; } },
+  mappings: async (opts: CliOptions) => { try { await stepMappings({ encounter: opts.encounter, raidhelperEvent: opts.raidhelperEvent, state: opts.state }); } catch (e) { console.error('mappings failed:', errMsg(e)); process.exitCode = 1; } },
   timeline: async (opts: CliOptions) => { try { await stepTimeline(opts); } catch (e) { console.error('timeline failed:', errMsg(e)); process.exitCode = 1; } },
   community: async (opts: CliOptions) => { try { await stepCommunity(opts); } catch (e) { console.error('community failed:', errMsg(e)); process.exitCode = 1; } },
-  generate: async (opts: CliOptions) => { try { await stepGenerate(opts); } catch (e) { console.error('generate failed:', errMsg(e)); process.exitCode = 1; } },
+  generate: async (opts: CliOptions) => { try { await stepGenerate({ state: opts.state, encounter: opts.encounter, raidhelperEvent: opts.raidhelperEvent }); } catch (e) { console.error('generate failed:', errMsg(e)); process.exitCode = 1; } },
   push: async (opts: CliOptions) => { try { await stepPush(opts); } catch (e) { console.error('push failed:', errMsg(e)); process.exitCode = 1; } },
   run: async (opts: CliOptions) => {
     try {
-      const { report, fight, encounter, instance, state } = opts;
-      const r = report ?? (await promptUser('Report code: '));
-      const f = fight ?? Number(await promptUser('Fight id: '));
-      const e = encounter ?? (await promptUser('Encounter name/id: '));
-      if (!r || !f || !e) throw new Error('report, fight and encounter are required (or set RAID_HELPER_EVENT_ID for the roster)');
-      await stepMappings({ encounter: process.env.RAID_HELPER_EVENT_ID || e, state });
-      await stepTimeline({ report: r, fight: f, instance, state });
-      await stepCommunity({ encounter: e, instance, state });
-      await stepGenerate({ state });
+      const { report, fight, encounter, instance, state, raidhelperEvent } = opts;
+      const rosterEventId = raidhelperEvent ?? process.env.RAID_HELPER_EVENT_ID;
+      if (!rosterEventId) throw new Error('run needs the raid roster — pass -R/--raidhelper-event or set RAID_HELPER_EVENT_ID');
+      await stepMappings({ raidhelperEvent: rosterEventId, state });
+      if (report) {
+        if (!fight) throw new Error('run --report requires --fight');
+        await stepTimeline({ report, fight, instance, state });
+      }
+      if (encounter) await stepCommunity({ encounter, instance, state });
+      await stepGenerate({ state, encounter, raidhelperEvent: rosterEventId });
     } catch (err) { console.error('run failed:', err); process.exitCode = 1; }
   },
   review: async (opts: CliOptions) => {
@@ -302,14 +312,21 @@ const handlers: Handlers = {
 async function interactiveMenu() {
   const base = { state: DEFAULT_STATE };
   try {
-    const report = process.env.RAID_HELPER_REPORT || (await promptUser('Report code: '));
-    const fight = process.env.RAID_HELPER_FIGHT ? Number(process.env.RAID_HELPER_FIGHT) : Number(await promptUser('Fight id: '));
-    const encounter = process.env.RAID_HELPER_ENCOUNTER || (await promptUser('Encounter name/id: '));
-    if (!report || !fight || !encounter) { console.log('Missing required inputs — aborting.'); return; }
-    await stepMappings({ encounter: process.env.RAID_HELPER_EVENT_ID || encounter, state: DEFAULT_STATE });
-    await stepTimeline({ report, fight, instance: 'classic', state: DEFAULT_STATE });
-    await stepCommunity({ encounter, instance: 'classic', state: DEFAULT_STATE });
-    await stepGenerate({ state: DEFAULT_STATE });
+    // Generation needs a RaidHelper roster (report/fight are the analysis lane).
+    const rosterEventId = (process.env.RAID_HELPER_EVENT_ID || (await promptUser('RaidHelper event id (roster; blank = use existing state): '))) ?? null;
+    if (!rosterEventId && !readJSON(resolveState(DEFAULT_STATE), 'rolemappings.json')) {
+      console.log('No RaidHelper roster and no saved mappings — run `generate -R <event id> -e <encounter>` instead.');
+      return;
+    }
+    if (rosterEventId) await stepMappings({ raidhelperEvent: rosterEventId, state: DEFAULT_STATE });
+    const encounter = (process.env.RAID_HELPER_ENCOUNTER || (await promptUser('Encounter name/id (blank = use existing state): '))) ?? '';
+    const report = (process.env.RAID_HELPER_REPORT || (await promptUser('Report code (blank = skip the report/analysis lane): '))) ?? '';
+    if (report) {
+      const fight = process.env.RAID_HELPER_FIGHT ? Number(process.env.RAID_HELPER_FIGHT) : Number(await promptUser('Fight id: '));
+      await stepTimeline({ report, fight, instance: 'classic', state: DEFAULT_STATE });
+      await stepCommunity({ encounter, instance: 'classic', state: DEFAULT_STATE });
+    }
+    await stepGenerate({ state: DEFAULT_STATE, encounter, raidhelperEvent: rosterEventId ?? undefined });
 
     while (true) {
       console.log('\n--- Interactive Mode ---');

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -125,10 +125,9 @@ test('mappings dispatches with the encounter', () => {
   assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'mappings'); assert.equal(o.encounter, ARGS.encounter); assert.equal(o.state, undefined);
 });
 
-test('mappings requires --encounter (exit 1)', () => {
+test('mappings requires an event source: -R missing => handled at runtime, not a commander error', () => {
   const { error } = run(['mappings']);
-  assert.equal(error.exitCode, 1);
-  assert.match(error.message, /required option '-e, --encounter <name\|id>' not specified/);
+  assert.ifError(error); // commander parses fine; the handler raises at runtime
 });
 
 test('community dispatches with the encounter', () => {
@@ -141,6 +140,51 @@ test('generate runs with no required options', () => {
   const { calls, error } = run(['generate']);
   assert.ifError(error);
   assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'generate'); assert.equal(o.state, undefined);
+});
+
+test('generate dispatches -R/--raidhelper-event (roster id, no report)', () => {
+  const R = '1542926745605242951';
+  const { calls, error } = run(['generate', '-R', R]);
+  assert.ifError(error);
+  assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'generate'); assert.equal(o.raidhelperEvent, R);
+});
+
+test('run dispatches -R, -e, and -r/-f independently', () => {
+  const { calls, error } = run(['run', '-R', '1542926745605242951', '-e', 'Immerseus', '-r', 'aBcDeFgH1Xx', '-f', '2']);
+  assert.ifError(error);
+  assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'run');
+  assert.equal(o.raidhelperEvent, '1542926745605242951');
+  assert.equal(o.encounter, 'Immerseus');
+  assert.equal(o.report, 'aBcDeFgH1Xx');
+  assert.equal(o.fight, 2);
+});
+
+test('mappings dispatches -R as the RaidHelper event (encounter optional)', () => {
+  const R = '1542926745605242951';
+  const { calls, error } = run(['mappings', '-R', R]);
+  assert.ifError(error);
+  assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'mappings'); assert.equal(o.raidhelperEvent, R); assert.equal(o.encounter, undefined);
+});
+
+test('mappings requires an event source: -R missing => handled at runtime, not a commander error', () => {
+  const { calls, error } = run(['mappings']);
+  assert.ifError(error); // commander parses fine; the handler raises at runtime
+  assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'mappings'); assert.equal(o.raidhelperEvent, undefined); assert.equal(o.encounter, undefined);
+});
+
+test('community dispatches -R (raidhelper) + -e (encounter name) together', () => {
+  const R = '1542926745605242951';
+  const { calls, error } = run(['community', '-R', R, '-e', 'Immerseus']);
+  assert.ifError(error);
+  assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'community'); assert.equal(o.raidhelperEvent, R); assert.equal(o.encounter, 'Immerseus');
+});
+
+test('explicit -R beats RAID_HELPER_EVENT_ID env when both are set (flag > env)', () => {
+  const R = '1542926745605242951';
+  const { calls, error } = run(['run', '-R', R, '-e', 'Immerseus', '-r', 'aBcDeFgH1Xx', '-f', '2']);
+  assert.ifError(error);
+  assert.equal(calls.length, 1); const [n, o] = calls[0]; assert.equal(n, 'run');
+  assert.equal(o.raidhelperEvent, R); // the flag wins even if the env were set
 });
 
 test('run accepts missing params (prompted later, not a commander error)', () => {


### PR DESCRIPTION
Part of #17. Implements #19 (C0).

Raid-night generation no longer needs a WCL report. `generate`, `run` and the bare menu work from roster (RaidHelper) + community + baked vocabulary; `-r/--report` is optional. New `-R/--raidhelper-event`; `-e` stays the encounter. Precedence: flag > env > prompt everywhere. `generate` auto-fetches roster when -R passed. 75/75 unit tests green. Live: mappings -R resolves 24 players; model dispatch settles (auth via OPENCODE_API_KEY, no stall).