### PR TITLE
fix(render): bind player names to col A; push re-renders from committed.json — clean rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ node_modules/
 backups/
 dist/backups/
 dist/
+# agent session memory / private working notes are never source-controlled
+.openhands/
+# captured reference payloads + runtime-generated raid artifacts are not source
+ref/
+tonight/
+*.csv

--- a/docs/plans/community-analysis-engine.md
+++ b/docs/plans/community-analysis-engine.md
@@ -1,0 +1,59 @@
+# Community Analysis Engine — design (agreed)
+
+Status: **agreed design** (2026-09-02 grilling session). Not yet built.
+Companion research ticket: [R3 (#41)](https://github.com/bffs-wow/assignments/issues/41) — statistician-agent personas, tools & analysis patterns.
+
+## Motivation
+
+Tonight's generated Immerseus assignments were **well-formed but unevidenced**: no `timeline.json`, no `community.json`, so the generator planned from a bare canonical-event whitelist. We want a **learned community-knowledge engine** that accumulates mid-tier 25H kill evidence per boss and derives raid-cooldown strategy that improves over time.
+
+## Decisions (all confirmed by the operator)
+
+### Scope / inputs
+- **Single-report / single-pull analysis stays in scope as a runtime input only** — never a hard-coded config value. Today `timeline -r <code> -f <fight>` already does this. No R2-style seeded report ID in code.
+- **Community lane is the default evidence source**: rank-band sampling of *mid-tier 25H kills* (not world-first), deduped by report+fight.
+
+### Corpus / persistence
+- **SQLite** under `.cache/community/community.db` (`.cache/` already gitignored). One corpus across bosses.
+- Tables:
+  - `pulls` — id, boss, code, fightID, date, deaths, duration, guild, server, rankBand, pulledAt; UNIQUE(boss, code, fightID) (INSERT OR REPLACE → idempotent re-pulls)
+  - `events` — id, pullId, timestamp, abilityName, context (aligned boss ability), eventName
+  - `strategies` — id, boss, eventName, occurrence, primaryCd, altCd, confidence, sampleSize, deathsAvg, generatedAt
+  - `aggregates` — id, boss, metric, value, computedAt
+  - `pull_results` — pullId, kill, deaths, wipe, duration, committedSnapshot, notes (outcome tracking → enables "strategies proven on clean nights" weighting)
+
+### Pull filters
+- `--deaths-max <n>` (**default 2**, `0` available): hard-skip a pull when its Deaths event-stream count exceeds the cap; log the skip.
+- **"Alive at kill" sanity flag** recorded (not gating) for later learning.
+- **Recency**: `--recent 7d` default; **fallback to 30d then all-time** when < 2 distinct band pulls within the window; always record `windowUsed` + `sparse` flag.
+
+### Analysis / aggregation (deterministic anchor + agent prose pass)
+- **Deterministic layer** (testable, no model drift):
+  - **Time-window modes** primary: per boss-event occurrence (from baked cadence / actual cast timestamps), count cooldown casts in `[cast ± window]`; top-2 = primary/alt with `confidence = share`, `sampleSize = #pulls using any CD that occurrence`.
+  - **Context-string modes** fallback when occurrence data missing.
+  - **Distinct strategies**: the 2–3 assignments whose shares sum > 0.8.
+- **`CommunityAnalyst` agent** provides the human-readable prose on top of computed aggregates (single-shot today; may become richer with R3 findings).
+- **Generator input**: keep prose `communityStrategy` **and** add structured `communityModes` into `initialData` (`{boss, event, occurrence, primaryCd, altCd, confidence, sampleSize}`).
+- **Confidence floor**: don't feed a mode to `generate` if `sampleSize < 3`; mark `lowConfidence`.
+
+### Learning / optimization over time
+- **Recompute on every community run** (deterministic, idempotent): re-aggregate all stored pulls for the boss, update `strategies` + `aggregates`. Modes/confidence shift as good pulls accumulate.
+- **Outcome weighting**: `pull_results` lets future aggregation weight strategies by "killed / clean night."
+- **No auto-`generate`** — the cron collects + recomputes + writes an advisory report; it never silently mutates committed assignments (raid-night-critical).
+
+### Scheduled automation (Agent Canvas prompt-cron)
+- Cron runs `community` for the 14 SOO bosses (collect + recompute, deterministic) **plus an agent pass** that reads the corpus + last pushed sheet rows + `committed.json`, validates against learned modes, and files a report / updates the map with "what changed, what to try, what's low-confidence."
+- Deterministic collection is a **custom script** (no LLM per-run); the agent pass is a **prompt preset** (`/api/automation/v1/preset/prompt`, cron trigger, timezone). Respect WCL rate limits (service already has backoff + page caches).
+- Local deployment → cron (polling) is correct; no inbound webhooks.
+
+## Authored-as-files
+
+- Research ticket: `#41` (R3). Map #17 updated: R3 added to Research (now), Frontier = T3/T4/R2/R3.
+- This doc is the durable record of the agreed design (replace `docs/plans/community-analysis-engine.md` as it evolves).
+
+## Open (next frontier, post-R3)
+
+- Exact cron schedule / timezone for the collector + agent pass.
+- Report/issue delivery channel for the agent pass.
+- "1-line rationale for a mode change" format.
+- R3 findings → finalize the aggregation algorithm + small-sample confidence rule + correlation/clustering methods.

--- a/docs/plans/community-analysis-engine.md
+++ b/docs/plans/community-analysis-engine.md
@@ -51,6 +51,13 @@ Tonight's generated Immerseus assignments were **well-formed but unevidenced**: 
 - Research ticket: `#41` (R3). Map #17 updated: R3 added to Research (now), Frontier = T3/T4/R2/R3.
 - This doc is the durable record of the agreed design (replace `docs/plans/community-analysis-engine.md` as it evolves).
 
+## Next steps
+
+1. **R3 (#41)** — research the statistician-agent patterns (prompt/persona, tools, correlation/clustering/small-sample methods, agent-loop design) → lands findings in `docs/research/statistician-agent-research.md` + resolution comment with build recommendations.
+2. **R2 (#21)** — close out (log + comment), per the frontier.
+3. **Build tickets** (new, to be created): SQLite schema + collection run; `--deaths-max`/`--recent` filters; deterministic aggregation + `communityModes` → `generate`; `pull_results` outcome tracking; Agent Canvas prompt-cron (collector script + agent pass).
+4. **Prune the hard-coded report anchor** — already none in code; keep it that way (R2's `vhLNKJTwtq2ydgVm` stays a doc/issue reference only).
+
 ## Open (next frontier, post-R3)
 
 - Exact cron schedule / timezone for the collector + agent pass.

--- a/docs/research/r2-agent-surface.md
+++ b/docs/research/r2-agent-surface.md
@@ -1,0 +1,63 @@
+# R2 — Research: how a general agent consumes a CLI + artifact store
+
+**Ticket:** [R-A — How a general agent consumes a CLI + artifact store (skills/tools)](https://github.com/bffs-wow/assignments/issues/38) · **Map:** [#37](https://github.com/bffs-wow/assignments/issues/37)
+**Status:** resolved AFK · **Date:** 2026-08-22
+
+## Question
+
+How does a general agent harness (OpenHands / Claude Code / similar) most idiomatically consume a CLI + artifact-store application like this one? Three sub-questions: (1) skill docs vs MCP vs native tools, (2) is a CLI writing JSON artifacts to a state dir an adequate seam, (3) how agent-driven flows handle a human-confirm write gate.
+
+## Grounding used
+
+- **This repo's own convention** (primary, local): `AGENTS.md` routes agents to `docs/agents/*.md` skills (issue-tracker, triage-labels, domain) — the "Matt Pocock" model of repo-supplied agent instructions. The current working session proved the pattern end-to-end: a general agent drove `generate` / read `sheets-rows.json` errors / `refine` / reconcile against the reference sheet via CLI one-shots + artifact reads, with no MCP and no custom wrapper.
+- **The general agent harness in use** (OpenHands / Agent Canvas): skills are freeform Markdown invoked by the agent (`.openhands/skills/`, repo `docs/agents/`, `AGENTS.md`); the agent has a terminal + file tools and shells out to CLIs naturally.
+- **Reference conventions** (official/primary):
+  - OpenHands CLI + skills model — https://docs.openhands.dev/ (skills are repo/user-supplied Markdown; the harness owns the conversational loop, memory, tool orchestration).
+  - Anthropic Claude Agent Skills — the `SKILL.md`-in-`skills/` convention (front-matter description; progressive disclosure; freeform instructions, not code).
+  - MCP spec — the Model Context Protocol for exposing *tools* (server-side RPC) when a harness should call operations as native tools rather than parse CLI output.
+
+## Findings
+
+### 1. Skill docs vs MCP vs native tools
+
+The deciding factor is **who owns the conversational loop and tool orchestration**:
+
+- **Skill doc (repo or user-supplied Markdown)**: the right default. The harness already *has* the loop, memory, file tools, and terminal. A skill doc teaches the agent *how to drive the app with its existing tools* (run this binary, read that artifact, interpret these errors). Zero infrastructure; matches this repo's existing `docs/agents/*.md` convention; the agent can chain operations and human-feedback turns ad hoc, which is exactly what the delivery loop (generate → review errors → refine → push) needs.
+- **Native tools / direct shell**: the same thing without the documentation layer. Fine for a *single* well-known command, but a delivery flow with validation semantics, artifact grammar, and write gates needs the doc. The CLI is already a native tool surface; the skill doc is what makes it *usable* by an agent.
+- **MCP tools**: only warranted when a harness should call operations as **typed, discoverable RPC endpoints** rather than shell out — i.e. when the *consumer* is an MCP client (an editor, a distinct harness) that wants schema-typed tools, or when an operation returns structured data that's painful to parse from stdout. Here the app already emits structured **artifacts** (JSON files), so stdout parsing isn't the bottleneck. MCP adds a server, transport, and auth for no gain in this shape.
+
+**Conclusion (Q1):** Skill doc over the existing CLI + artifact store is idiomatic. MCP is downstream packaging only if a future consumer needs typed tools; not needed to make the app agent-driven.
+
+### 2. Artifact contract
+
+A CLI that writes JSON artifacts to a state dir is an **adequate and even ideal seam**, provided:
+
+- The artifacts are the **source of truth for the agent's next step** (not log text). `committed.json`, `sheets-rows.json`, `rolemappings.json` already are: the agent reads `sheets-rows.json.errors` to decide whether to `refine`, reads `committed.json` to review, reads `rolemappings.json` to reason about roster drift.
+- **Error semantics need to be machine-actionable.** Today validation failures are strings in `sheets-rows.json.errors` (e.g. "row 12: BOSS HEALTH / SPELL must be a known event"). An agent handles those fine, but the convention could be tightened cheaply: stable **error codes** (`ERR_UNKNOWN_EVENT`, `ERR_BAD_OCCURRENCE`, ...) + the affected row/field, so an agent matches on codes rather than prose. This is a *nice-to-have*, not a blocker.
+- **Exit codes matter** (0 = success, non-zero = the operation failed *before* producing artifacts) so the agent can distinguish "no output" from "valid empty".
+- The one gap: **schemas**. The artifacts are JSON but untyped. A cheap `src/data/*.schema.json` or TS type re-export (the app already has `assignments-schema.ts`) lets an agent validate what it reads. Again optional.
+
+**Conclusion (Q2):** The artifact store is sufficient today. The only tightening worth doing (and worth a P-A/G-A mention) is stable error **codes** + documented exit-code convention — no new tool surface required.
+
+### 3. Write gates
+
+The working convention for agent-driven flows that hit a shared/external side effect:
+
+- **Make the gate a flag, not a prompt.** A CLI that interactively prompts is hostile to an agent (a prompt can block a non-TTY/agent context). The app already has `push --yes`. An agent sets `--yes` **after it has satisfied the validation preconditions** (read `sheets-rows.json`, confirmed zero errors, shown the human a review). The flag encodes "the agent verified," not "the human clicked."
+- **Separate the tiers.** Human-confirm belongs at the *irreversible/wide-audience* boundary: the **production** raid sheet. The app's existing philosophy (`CONTEXT.md` write-gate: test sheet is the operational destination, production never written until proven) is exactly right — keep `push --yes` for the **test** sheet, and make the **production** sheet require an explicit human step (a separate flag or a `--target production` that human types).
+- **Precedent:** this is how agents handle destructive/irreversible ops generally — the harness shows the human the exact command + effect, the human authorizes it, and only then does the agent proceed. The app's `push` already backs up to `backups/` first, which is the right belt-and-suspenders.
+
+**Conclusion (Q3):** `push --yes` (agent-verified) targeting the **test** sheet with backups is idiomatic; the **production** sheet stays a human-confirmed gate. No interactive prompt in the agent path.
+
+## Recommendation for THIS app
+
+> The idiomatic surface is a **repo-supplied skill doc** (`docs/agents/raid-cli.md`) over the **existing commander one-shots + artifact store**, with the current write-gate philosophy kept (test = `--yes`, production = human). No MCP server, no new wrapper, no `--json` duplication. Two optional cheap tightenings: stable validation **error codes** and an **exit-code convention** in the skill doc.
+
+This is exactly the shape the current working session already exercised successfully, so the prototype (P-A) should capture it in writing and G-A should lock it as authoritative.
+
+## Sources
+
+- OpenHands docs — https://docs.openhands.dev/ (CLI mode; agent skills model).
+- Anthropic Agent Skills / Claude Code — `SKILL.md` convention (progressive disclosure, freeform instructions).
+- MCP specification — https://modelcontextprotocol.io/ (typed tool RPC; when to reach for it).
+- This repo: `AGENTS.md`, `docs/agents/*.md`, `CONTEXT.md` (write-gate philosophy), `src/shared/assignments-schema.ts`, CLI surface in `src/cli.ts` + `src/index.ts` (one-shots + `.cache/cli/` artifacts).

--- a/docs/research/statistician-agent-research.md
+++ b/docs/research/statistician-agent-research.md
@@ -1,0 +1,162 @@
+# R3 — Research: statistician-agent personas, tools & analysis patterns for the community-corpus engine
+
+**Ticket:** [R3 — Research: statistician-agent personas, tools & analysis patterns for the community-corpus engine (learned knowledge base)](https://github.com/bffs-wow/assignments/issues/41) · **Map:** [#17](https://github.com/bffs-wow/assignments/issues/17)
+**Status:** research → findings · **Date:** 2026-08-22
+**Companion design:** `docs/plans/community-analysis-engine.md` (agreed) — SQLite corpus (pulls/events/strategies/aggregates/pull_results), deterministic time-window modes + agent prose pass, sample-size floor 3, outcome weighting, Agent Canvas prompt-cron.
+
+---
+
+## Scope
+
+Find the state of the art for each of the R3 questions, matching the agreed engine's shapes:
+
+| R3 ask | Matching engine shape |
+|---|---|
+| 1. Statistician-agent prompting / personas | `CommunityAnalyst` prose pass + cron agent pass |
+| 2. Tooling | deterministic aggregation layer (testable, no model drift) |
+| 3. Correlation/co-occurrence | "is a CD cast correlated with a boss event within a window" |
+| 4. Multiple-comparison control | scanning many event×CD cells for modes |
+| 5. Small-sample confidence | `sampleSize` 3–10 pushes |
+| 6. Outcome weighting | `pull_results` (kill / clean night) → strategy weighting |
+| 7. Agentic analysis-loop | collect → aggregate → summarize → propose → validate |
+
+---
+
+## 1. Statistician-agent personas & prompting
+
+**Well-established pattern: the "data analyst / statistician" persona agent.** Rather than one giant LLM prompt, the effective pattern is a **structured reasoning loop with explicit statistical framing**:
+
+- **Persona = "tabular/data analyst"**: instructs the model to: (1) state the question as a testable claim, (2) compute from the data (not prose), (3) report effect size + uncertainty (not just significance), (4) state assumptions/limits, (5) recommend action. This is the "statistician agent" persona: rigorous, quantifies uncertainty, never asserts a pattern without a measure.
+- **Key anti-hallucination rule**: the agent must **call a deterministic tool for every number it cites** — no computed-from-memory. This is the direct answer to the ticket's "hallucinated stats" failure mode.
+- **"Charting-driven analysis loop"**: the analyst alternates compute → inspect → hypothesize → compute, with the authority to slice the data. For our engine the "chart" is the *deterministic mode table* — the agent reads it, doesn't re-derive it.
+
+**Primary sources**
+- Statistical "data analyst agent" prompt patterns are documented in the LLM-agent tooling literature; the durable principle is *numbers come from tools, not the model*. See the OpenHands/agent-skills tooling model (https://docs.openhands.dev/) and the statistical-reasoning guidance in modern data-science agent toolkits. The "statistician persona" also maps to the **EPP (Enumerate-Possibilities-Plan)** and "thought → action → observation" ReAct pattern — the model toggles between tool calls and reasoning.
+- When the persona is a *domain* analyst (raid cooldowns), the strongest practice is: **ground the persona in the domain's event vocabulary** (here: the baked SOO vocabulary, ADR-0001) so "correlation" always means *these events×CDs*, never free-form ability names.
+
+**For this engine**: the persona pattern to adopt is **"automated statistician"**: the `CommunityAnalyst` (prose) is *fed* the deterministic aggregates and instructed to interpret them under small-sample rules, never to invent a statistic. The cron agent pass reads the corpus + aggregates and files advisory findings, citing computed numbers only.
+
+---
+
+## 2. Tooling
+
+The ticket asks for established deterministic, code-based statistical tooling. Grounding for a **typescript/Node** codebase (no heavy Python runtime required):
+
+- **SQL is a statistical query tool.** Our corpus is SQLite. Deterministic modes are expressible as SQL aggregates (`GROUP BY event, occurrence, cd`, windowed `WHERE` on timestamps) — this is the "pandas/SQL-based patterns" the ticket names, and keeps the layer testable (the agreed design's "deterministic anchor").
+- **If/when heavier stats are needed**: the established suites are **pandas + scipy/statsmodels** (Python ecosystem) and **R**. For a Node repo, `simple-statistics` / `jstat` cover bootstrap, percentiles, chi-square, t-tests without a Python dependency. The agreed design says *deterministic, testable, code-based* — SQL + a small math lib in the app's language is the minimal, idiomatic fit.
+- **"Tabular reasoning" toolset for a sub-agent**: a sub-agent handed a dataset benefits from being able to run **SQL against the corpus** (deterministic) rather than eyeballing JSON. If the cron agent pass needs live querying, giving it a `query_corpus(sql)` tool (the WCL-Explorer pattern already in this repo) is the established shape.
+
+**For this engine**: keep aggregation in **SQL + app-typed code** (testable, matches the agreed design). No Python service. Optionally add a `simple-statistics`-style dependency for bootstrap/CIs if small-sample confidence needs beyond simple proportions. The deterministic layer stays the single source of numbers; the agent prose pass consumes it.
+
+---
+
+## 3. Correlation / co-occurrence of events (CD × boss event in a window)
+
+The agreed engine's deterministic mode is already a **co-occurrence count** (CD cast inside `[event_cast ± window]`). The mathematical upgrades established for this "market-basket" shape (the ticket's explicit analogy):
+
+- **The market-basket/association-rule frame is exactly right.** CD×event co-occurrence = itemset analysis. The standard measures:
+  - **Support** = P(CD and event co-occur) = count(co-occurring pushes)/N. *Fragile at small N — drives the small-sample rule below.*
+  - **Confidence** = P(CD | event) = count(CD and event together)/count(event). **This is already `confidence = share` in the agreed design** — the primary/alt CD shares sum toward 1.0.
+  - **Lift** = P(CD|event)/P(CD) — whether a CD is *more likely given the event than its base rate*. **The key missing measure**: a CD used "whenever any hard thing happens" (high base rate) will have high confidence for *every* event; lift discounts that and surfaces *specific* CD×event pairings. **Recommendation: add lift alongside confidence** to distinguish "the staple CD" from "the CD that specifically answers this event."
+  - **(Pointwise) Mutual Information (PMI)** = log(P(CD,event)/(P(CD)P(event))) — the information-theoretic sibling of lift; ranks pairs by how much more they co-occur than chance. Lift and PMI are monotone-equivalent for the same marginals; pick lift (interpretable: "2.1× as likely") and/or PMI as a ranking.
+  - **Chi-square / significance** of a CD×event cell = whether the observed co-occurrence exceeds expected under independence. Useful as a *filter* (only report cells that can't be explained by chance given other CDs), but **see §4/§5 for the multiple-comparison + small-sample caveats**.
+
+**For this engine**: keep `confidence = share` as the headline, **add `lift`** (and optionally PMI) computed deterministically, and treat **chi-square as an optional significance filter with the FDR guard from §4**, not a hard gate at small N.
+
+---
+
+## 4. Multiple-comparison / false-discovery control when scanning many event×CD cells
+
+The engine scans *many* (event × occurrence × CD) cells for "modes." Naively reporting the highest-confidence cells **overfits** — with enough cells, some look great by chance.
+
+- **The established correction families**:
+  - **Bonferroni** (FWER): adjusted p = p × (#cells). Simple but *very* conservative — at small N it erases everything. Bad fit here.
+  - **Benjamini–Hochberg (BH) FDR** (the standard for exploratory many-cell scans): controls the *expected proportion of false discoveries* among the cells you call significant. **This is the right frame** for "which CD×event cells are real modes."
+- **Practical consequence for this engine**: with tiny sample sizes (3–10), formal FDR on raw p-values is usually impossible to meet. So the **guard is two-layered**:
+  1. **Structural**: only scan cells for *events that actually occur* in the corpus (the agreed design already keys on baked occurrences) — collapses the cell count to what the data supports.
+  2. **Reporting**: use BH-FDR to *rank/report* (only surface cells passing FDR when N is large enough to support it), and otherwise fall back to the §5 small-sample rule. Never report "p < 0.05" from a 4-push scan.
+- **Anti-p-hacking structural guard**: **pre-register the aggregation** (fixed window, fixed occurrence set, fixed method) and make it *idempotent* (recompute = same result). The agreed design's "deterministic, idempotent recompute" is exactly this.
+
+**For this engine**: use **BH-FDR** as the many-cell reporting rule when N supports it; otherwise the small-sample rule of §5 governs. Do NOT use Bonferroni. Keep the cell universe fixed by the baked occurrence vocabulary (ADR-0001) — that's the pre-registration.
+
+---
+
+## 5. Small-sample statistics (sampleSize 3–10)
+
+The engine's confidence floor is `sampleSize < 3 → don't feed generate`; R3 asks how to *report confidence when sampleSize is 3–10 without overclaiming*. The established methods, in ascending rigor:
+
+- **Exact methods over asymptotics** when N is tiny:
+  - **Binomial proportion + exact CI (Clopper–Pearson)** reports `confidence = share` with a correct small-sample interval, e.g. 6/8 → share 0.75, 95% CI [0.35, 0.97]. Wide interval = the honest signal. **This is the headline recommendation** — a simple, exact, defensible interval, easy to compute (no Python; a small function or `simple-statistics`).
+  - **Fisher's exact test** for CD×event 2×2 tables — the small-sample replacement for chi-square (chi-square is asymptotic and invalid at N<5 per cell).
+- **Bayesian shrinkage / smoothing**: instead of a raw proportion, shrink toward a prior (e.g. add a pseudo-count, or a Beta-binomial with a neutral prior). Prevents "2/2 = 100% confident" absurdities. **Use a mild Beta-binomial (or Laplace/Jeffreys add-α/2 pseudo-counts) so a 1-of-1 cell isn't reported as share 1.0.** The agreed design's "don't feed if N<3" already prevents the worst case; shrinkage makes the 3–10 range honest.
+- **Bootstrap**: resample the observed pushes to get a CI for the share. Fine once N is ≥ ~10; at N<5 it's noisy and the exact Clopper–Pearson is better. **Defer bootstrap to N≥10.**
+- **Reporting language**: replace "73% confidence" with "5/7 pushes used Devotion Aura here; exact 95% CI 0.35–0.97". An agent/reader can't over-read a CI.
+
+**For this engine — the confidence rule to adopt:**
+- N < 3: **do not feed to generate** (existing floor), mark `lowConfidence`.
+- 3 ≤ N < 10: report `share` + **Clopper–Pearson exact 95% CI** (or Beta-binomial shrink with a weak prior to avoid 100%/0% cells), *no* chi-square.
+- N ≥ 10: can add bootstrap CI + optional BH-FDR over cells.
+- Never report a bare p-value at N<10.
+
+---
+
+## 6. Outcome weighting (strategies "proven on clean kills")
+
+`pull_results` tracks kill/wipe/deaths/duration → "weight strategies by clean-night outcomes." The established frame is **survival/outcome-adjusted analysis**, but the *simple* correct version needs no survival machinery:
+
+- **The survival-analysis analog** (Kaplan–Meier, Cox) is overkill for "did tonight's kill use CD X on event Y." Those models answer *time-to-event* questions.
+- **The simpler, established pattern is outcome-subgroup / propensity-lite weighting**:
+  - **Stratified reporting**: report mode shares **separately for kill vs wipe** and prefer the kill-stratum when its N is sufficient (the "proven on clean nights" intent, exactly).
+  - **Outcome-weighting (inverse-variance / precision-weighted)**: weight each push's contribution by a function of outcome (clean kill = highest, wipe-with-many-deaths = lowest) — a deterministic scalar, not a model. This is the "simpler outcome-weighted stats" the ticket anticipates.
+  - **Don't over-wheel**: with N 3–10, building a weighted estimator from 8 pushes adds noise; stratified reporting (kill vs wipe) is more honest than a single precision-weighted number at tiny N.
+- **"Alive at kill" sanity flag** (in `pull_results`) supports a *quality gate*: exclude pushes where the CD caster died before the recorded cast window (a CD "used" by a dead player isn't evidence).
+
+**For this engine — the outcome rule:**
+- Primary: report **kill-stratum modes** as the headline when N_kill ≥ 3, wipe-stratum as secondary context.
+- As a secondary cross-check once N grows: precision/outcome-weighting (simple scalar), not a full survival model.
+- Use the "alive at kill" flag to drop casts that can't be evidence.
+
+---
+
+## 7. Agentic analysis-loop design (collect → aggregate → summarize → propose → validate)
+
+The agreed cron does deterministic collection + recompute + an agent pass. The established agent-loop pattern for a growing dataset:
+
+- **The loop**: `collect → aggregate (deterministic) → summarize (agent) → propose (agent) → validate (deterministic re-check + human/operator confirm)`. The key discipline: **the deterministic steps decide, the agent narrates.** Never let the prose agent's summary alter the numbers (they come from a deterministic recompute).
+- **Tool handoff for the agent pass**: the range options are (a) feed it the recompute output as static context (simplest, idempotent), or (b) give it a `query_corpus(sql)` tool for live lookups (the WCL-Explorer pattern already in this repo). For a *cron advisor*, (a) static recompute output is enough and avoids the agent inventing numbers; (b) becomes worthwhile only when the pass must answer ad-hoc questions.
+- **Failure modes** (the ticket names them) and their guards:
+  | Failure | Guard |
+  |---|---|
+  | **Hallucinated stats** | agent only cites numbers produced by the deterministic layer; no arithmetic in prose |
+  | **Overfitting small N** | Clopper–Pearson CIs + don't-feed <3 (§5); report width, not just point |
+  | **p-hacking across cells** | fixed cell universe (baked vocabulary) + BH-FDR only when N supports (§4); recompute is idempotent |
+  | **Confirmation/recency bias** | window fallback (7d→30d→all) logged as `windowUsed` + `sparse` flag; never silently drop older evidence |
+  | **Silent mode drift** | "1-line rationale for a mode change" (already an open next-step in the design) — the agent pass always explains *why* a mode changed vs last recompute |
+- **Human-in-the-loop**: the cron *never* auto-`generate`s (agreed) — it writes an advisory report. That is the correct loop: the agent proposes, a human (or a deterministic gate) validates. The proposed report fields map: what changed, what to try, what's low-confidence — each backed by a computed number.
+
+**For this engine**: keep the loop shape `collect → aggregate → summarize → propose → validate`, give the agent pass the static recompute output (option a), and route the advisory report through a per-mode-change rationale line. Add `query_corpus(sql)` only if ad-hoc exploration becomes a need.
+
+---
+
+## Concrete build recommendations (for the resolution comment / implementation)
+
+1. **Persona**: an "automated statistician" persona for `CommunityAnalyst` + the cron agent pass — cite computed numbers only, state CI + sample size, never do arithmetic in prose.
+2. **Tools**: SQL aggregation in the app (no Python service); add a tiny stats lib (`simple-statistics` or a hand-rolled Clopper–Pearson/Beta-binomial) only for §5.
+3. ** Correlation:** keep `confidence = share` as headline; add **lift** (+ optional PMI) computed deterministically; treat chi-square as an optional, FDR-guarded filter.
+4. **Multiple comparisons**: **Benjamini–Hochberg FDR** is the reporting rule when N supports it; Bonferroni is out; the cell universe is fixed by the baked vocabulary (ADR-0001) as pre-registration.
+5. **Small sample**: N<3 → don't feed (existing); 3≤N<10 → `share` + Clopper–Pearson exact 95% CI (or Beta-binomial shrink), no chi-square; N≥10 → may add bootstrap + FDR. Never a bare p at N<10.
+6. **Outcome weighting**: headline = **kill-stratum modes** when N_kill≥3; wipe-stratum as context; precision-weighting only when N grows; use "alive at kill" to drop dead-caster evidence.
+7. **Agent loop**: `collect → aggregate → summarize → propose → validate`; agent pass reads static recompute output (option a); per-mode-change rationale line; no auto-generate.
+
+---
+
+## Sources
+
+- Agreed engine design — `docs/plans/community-analysis-engine.md` (companion).
+- Market-basket / association rules (support, confidence, lift): classic itemset-mining literature (Agrawal–Srikant); the standard treatment in data-mining textbooks (e.g. Han, Kamber, Pei, *Data Mining: Concepts and Techniques*).
+- Pointwise mutual information: standard NLP/information-theory references (Church–Hanks).
+- Multiple comparisons: Benjamini–Hochberg (1995) FDR; Bonferroni FWER.
+- Exact small-sample CIs: Clopper–Pearson (1934), exact binomial confidence interval; Fisher's exact test.
+- Bayesian shrinkage: Beta-binomial model; Laplace/Jeffreys pseudo-count smoothing.
+- Agent loop pattern (collect→aggregate→...→validate) and "numbers from tools, not prose": OpenHands agent/tooling model (https://docs.openhands.dev/), ReAct (Yao et al.) and the tool-augmented reasoning literature.
+- Survival analysis (Kaplan–Meier/Cox) marked out-of-scope for this simpler outcome weighting; stratified analysis preferred.

--- a/src/agents/assignment-generator.ts
+++ b/src/agents/assignment-generator.ts
@@ -18,11 +18,12 @@ export function AssignmentGenerator() {
 
   const writeAssignments = useDataWriter('assignments', { schema: v.array(assignmentSchema) });
 
-  const { timeline, roleMappings, skillsData, communityStrategy } = useInitialData<{
-    timeline: unknown[];
+  const { timeline, roleMappings, skillsData, communityStrategy, canonicalEvents } = useInitialData<{
+    timeline: unknown[] | null;
     roleMappings: Record<string, unknown>;
     skillsData: unknown;
     communityStrategy: string;
+    canonicalEvents: string[];
   }>();
 
   useTool({
@@ -57,21 +58,26 @@ ${timelineSection}
 
 ${strategySection}
 
+Canonical Event Whitelist:
+${JSON.stringify(canonicalEvents ?? [])}
+
 Rules for assignment:
+0. EVENT NAMES MUST BE EXACT: use only the event names from the "Canonical Event Whitelist" section below. Do NOT paraphrase, rename, or use community-strategy prose names. If the whitelist has numbered variants (e.g. "Overload 1".."Overload 10"), map each strategy mention to the specific numbered event. Use the exact string, including any boss-abbreviation suffix.
 1. Assign appropriate defensive and utility cooldowns to high-damage or high-risk events (like "Desperate Measures Sun", "Calamity", "Mark of Anguish").
 2. Respect cooldown durations. If a spell has a 180s cooldown, do not assign that exact player (e.g., DISC1) to use it again within 180 seconds.
 3. For heavy single target damage (like "Mark of Anguish"), assign tank externals like "Hand of Sacrifice" or "Pain Suppression", or personal tank cooldowns like "Shield Wall".
 4. For heavy raid damage (like "Calamity"), assign raid cooldowns like "Devotion Aura", "Healing Tide Totem", "Power Word: Barrier", or "Spirit Link Totem".
 5. For "Encounter Start", always assign "ALL" -> "Bloodlust".
 6. Do your best to spread out cooldowns so the raid is covered across all dangerous events.
-7. If Community Practices are provided, strongly prioritize mimicking those cooldown assignments for the respective events, assuming the required roles are available in the current roster.
+7. If Community Practices are provided, strongly prioritize mimicking those cooldown assignments for the respective events, assuming the required roles are available in the current roster — but always map their event names to the canonical whitelist.
 
 When the full assignment matrix is ready, call submit_assignments once with { assignments: [...] } — the complete array. Do not describe the assignments in prose — submit them via the tool.`;
 }
 
 AssignmentGenerator.initialData = v.object({
-  timeline: v.optional(v.array(v.unknown())),
+  timeline: v.optional(v.union([v.array(v.unknown()), v.null()])),
   roleMappings: v.record(v.string(), v.unknown()),
   skillsData: v.unknown(),
   communityStrategy: v.string(),
+  canonicalEvents: v.optional(v.array(v.string())),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,14 +150,15 @@ async function stepGenerate(opts: { state?: string; encounter?: string; raidhelp
   if (!timeline) console.warn('[generate] no timeline in state — refining from the roster/community only (report lane is optional)');
 
   const skillsData = JSON.parse(fs.readFileSync(new URL('../src/data/mop_skills.json', import.meta.url), 'utf8'));
+  const boss = resolveBoss(resolvedEncounter);
   const generator = init(AssignmentGenerator, { id: `generate-${Date.now()}` });
   const reply = await runAgent(generator, 'Generate the raid cooldown assignment matrix for this encounter.', {
     timeline, roleMappings, skillsData, communityStrategy: community?.communityStrategy ?? '',
+    canonicalEvents: boss?.events ?? [],
   });
   const assignments = reply.data?.assignments?.[0];
   if (!Array.isArray(assignments)) throw new Error('AssignmentGenerator did not submit assignments');
 
-  const boss = resolveBoss(resolvedEncounter);
   if (boss) {
     const { rows, errors } = renderCountRows({ assignments, roleMappings, boss });
     writeJSON(dir, 'sheets-rows.json', { encounter: boss.id, rows, errors, renderedAt: new Date().toISOString() });

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,8 +161,8 @@ async function stepGenerate(opts: { state?: string; encounter?: string; raidhelp
 
   if (boss) {
     const { rows, errors } = renderCountRows({ assignments, roleMappings, boss });
-    writeJSON(dir, 'sheets-rows.json', { encounter: boss.id, rows, errors, renderedAt: new Date().toISOString() });
     if (errors.length) console.error(`\n[generate] validation rejected ${errors.length} assignment(s) — push would be a no-op:\n` + errors.map((e) => `  - ${e.field}: ${e.message}`).join('\n'));
+    console.log(`\n[generate] ${rows.length} COUNT-block row(s) ready for ${boss.sheetName} (push re-renders from committed.json).`);
   }
   writeJSON(dir, 'committed.json', { assignments, roleMappings, encounter: resolvedEncounter || undefined, generatedAt: new Date().toISOString() });
   const tsv = `${CSVFormatter.formatToTSV(assignments, roleMappings)}\n`;
@@ -199,13 +199,6 @@ async function stepRefine(opts: { state?: string }, feedback: string): Promise<A
   fs.writeFileSync(path.join(dir, 'assignments.tsv'), `${CSVFormatter.formatToTSV(assignments, committed.roleMappings)}\n`);
   console.log(`Refined to ${assignments.length} assignments.\n-> ${path.join(dir, 'assignments.tsv')}`);
   console.log(`${CSVFormatter.formatToTSV(assignments, committed.roleMappings)}\n`);
-  if (committed.encounter) {
-    const boss = resolveBoss(committed.encounter);
-    if (boss) {
-      const { rows, errors } = renderCountRows({ assignments, roleMappings: committed.roleMappings, boss });
-      writeJSON(dir, 'sheets-rows.json', { encounter: boss.id, rows, errors, renderedAt: new Date().toISOString() });
-    }
-  }
   await autoPush(dir, { encounter: committed.encounter, assignments, roleMappings: committed.roleMappings });
   return assignments;
 }
@@ -220,11 +213,11 @@ function sheetsCredsPresent(): boolean {
 /**
  * B4: push the committed assignments to the test raid sheet's COUNT block.
  *
- * Consumes the persisted, already-rendered 13-col rows (`sheets-rows.json`,
- * written by generate/refine) — the push is lossless, exactly the convention
- * the sheet uses. Falls back to re-rendering committed.json when the rows
- * artifact is missing. The CSV/TSV artifact is unaffected on any failure —
- * sheets problems are loud warnings, never a hard pipeline failure.
+ * Always re-renders the committed plan with the current renderer (player
+ * bindings, canonical events) — the sheet is the source of truth for what
+ * went out, never a persisted snapshot. The CSV/TSV artifact is unaffected
+ * on any failure — sheets problems are loud warnings, never a hard pipeline
+ * failure.
  */
 async function stepPush(opts: { encounter?: string; state?: string; yes?: boolean }): Promise<void> {
   const dir = resolveState(opts.state);
@@ -239,17 +232,15 @@ async function stepPush(opts: { encounter?: string; state?: string; yes?: boolea
     process.exitCode = 1;
     return;
   }
-  const persistedRows = readJSON(dir, 'sheets-rows.json');
-  let rows: string[][] = Array.isArray(persistedRows?.rows) ? persistedRows.rows : [];
-  if (!rows.length) {
-    const { rows: rerendered, errors } = renderCountRows({ assignments: committed.assignments, roleMappings: committed.roleMappings, boss });
-    if (errors.length) {
-      console.error('\n[push] validation rejected the assignments — nothing written to the sheet:');
-      for (const e of errors) console.error(`  - ${e.field}: ${e.message}`);
-      process.exitCode = 1;
-      return;
-    }
-    rows = rerendered;
+  // Always re-render from the committed plan so the sheet gets the current
+  // renderer's columns (player binding, canonical events) — never a stale
+  // persisted sheets-rows.json snapshot.
+  const { rows, errors } = renderCountRows({ assignments: committed.assignments, roleMappings: committed.roleMappings, boss });
+  if (errors.length) {
+    console.error('\n[push] validation rejected the assignments — nothing written to the sheet:');
+    for (const e of errors) console.error(`  - ${e.field}: ${e.message}`);
+    process.exitCode = 1;
+    return;
   }
   if (!opts.yes) {
     console.log(`\nPush ${rows.length} assignment(s) to the live test sheet COUNT block for ${boss.sheetName}?`);
@@ -355,9 +346,17 @@ if (!isPlaceholder(process.env.OPENCODE_API_KEY) || !isPlaceholder(process.env.G
 }
 
 const argv = process.argv;
-if (argv.length <= 2) {
-  await interactiveMenu();
-} else {
-  createProgram(handlers).parse(argv);
+try {
+  if (argv.length <= 2) {
+    await interactiveMenu();
+  } else {
+    await createProgram(handlers).parseAsync(argv);
+  }
+} finally {
+  // Non-interactive shell: try to release the readline handle so the process
+  // can exit after a subcommand. In a TTY the interface stays open (menu loop);
+  // if stdin never closes, give the process a final nudge to exit.
+  rl.close();
+  process.exitCode = process.exitCode ?? 0;
+  if (!process.stdin.isTTY) setTimeout(() => process.exit(process.exitCode), 250);
 }
-process.exitCode = process.exitCode || 0;

--- a/src/serializer/bosses.ts
+++ b/src/serializer/bosses.ts
@@ -17,7 +17,10 @@ export interface SooBoss {
 }
 
 /** Group tags the export grid accepts in the PLAYER/CLASS/ALL column. */
-export const GROUP_TAGS = ['ALL', 'MELEEDPS', 'RANGEDDPS'] as const;
+export const GROUP_TAGS = [
+  'ALL', 'MELEEDPS', 'RANGEDDPS', 'TANKS', 'HEALERS',
+  'DEATHKNIGHT', 'DRUID', 'HUNTER', 'MAGE', 'MONK', 'PALADIN', 'PRIEST', 'ROGUE', 'SHAMAN', 'WARLOCK', 'WARRIOR',
+] as const;
 
 let cache: SooBoss[] | undefined;
 

--- a/src/serializer/render.ts
+++ b/src/serializer/render.ts
@@ -126,11 +126,16 @@ function bossScaffold(boss: SooBoss): string[][] {
   return rows;
 }
 
-function assignmentRow(a: Assignment): string[] {
+function assignmentRow(a: Assignment, roleMappings: Record<string, unknown> | null | undefined): string[] {
   const custom = !CANONICAL_SPELLS.includes(a.spellName);
   const row = Array<string>(13).fill('');
-  // Player (col A) is left blank — the sheet auto-resolves it from the
-  // role-name bindings (the plan's roleTag already resolves to a player).
+  // Player (col A): bind the plan's role tag to the rostered player name;
+  // group tags (ALL / MELEEDPS / …) and unmapped tags stay blank, matching
+  // the live sheet's convention (names on individual rows only).
+  const entry = a.roleTag ? roleMappings?.[a.roleTag] : undefined;
+  const mapped = typeof entry === 'object' && entry !== null && typeof (entry as { name?: unknown }).name === 'string'
+    ? (entry as { name: string }).name : '';
+  if (mapped) row[COL_PLAYER] = mapped;
   if (a.cd != null) row[COL_CD] = String(a.cd);
   row[COL_EVENT] = a.event;
   row[COL_COUNT] = String(a.occurrence);
@@ -163,7 +168,7 @@ export function renderSooAssigns(input: RenderInput): RenderResult {
 
   for (const b of allSooBosses()) {
     rows.push(...bossScaffold(b));
-    if (b.id === boss.id) rows.push(...sorted.map(assignmentRow));
+    if (b.id === boss.id) rows.push(...sorted.map((a) => assignmentRow(a, roleMappings)));
   }
 
   return { csv: `${rows.map(csvLine).join('\n')}\n`, errors: [] };
@@ -189,5 +194,5 @@ export function renderCountRows(input: RenderInput): { rows: string[][]; errors:
     (a, b) => (eventOrder.get(a.event) ?? 0) - (eventOrder.get(b.event) ?? 0) || a.timingOffset - b.timingOffset,
   );
 
-  return { rows: sorted.map(assignmentRow), errors: [] };
+  return { rows: sorted.map((a) => assignmentRow(a, roleMappings)), errors: [] };
 }

--- a/src/serializer/validate.ts
+++ b/src/serializer/validate.ts
@@ -41,8 +41,15 @@ export interface ValidateOptions {
   roleMappings?: Record<string, unknown> | null;
 }
 
-/** A single count or a comma-separated list of counts, e.g. "1", "1,4", "1, 4". */
-const occurrenceListRe = /^\s*\d+(?:\s*,\s*\d+)*\s*$/;
+/**
+ * A single count or a comma-separated list of counts, e.g. "1", "1,4", "1, 4".
+ * A lone negative count (e.g. "-1") is a legal pre-event/countdown call — the
+ * reference kill set uses `-1` on encounter start / pre-cast events to mean
+ * "call before the event". A negative *inside a list* is not meaningful.
+ */
+const occurrenceRe =
+  /^\s*(-?\d+)\s*$/;
+const occurrenceListRe = /^\s*(-?\d+)(?:\s*,\s*\d+)*\s*$/;
 
 export function validateAssignments(input: unknown, opts: ValidateOptions = {}): PlanValidation {
   const errors: ValidationIssue[] = [];
@@ -90,8 +97,8 @@ export function validateAssignments(input: unknown, opts: ValidateOptions = {}):
     }
     const occBad =
       typeof a.occurrence === 'number'
-        ? !Number.isInteger(a.occurrence) || a.occurrence < 0
-        : !occurrenceListRe.test(a.occurrence);
+        ? !Number.isInteger(a.occurrence) || (a.occurrence < 0 && a.occurrence !== -1)
+        : !(occurrenceRe.test(a.occurrence) || (occurrenceListRe.test(a.occurrence) && !a.occurrence.includes('-')));
     if (occBad) {
       errors.push({
         index,

--- a/test/unit/serializer-render.test.ts
+++ b/test/unit/serializer-render.test.ts
@@ -34,10 +34,10 @@ const goldenPlan: Assignment[] = [
 /** Expected assignment rows, sorted by master event order then TIME. */
 const goldenBlock = [
   `"","","Encounter Start (PAR)","1","ALL","0","Bloodlust","","","","","",""`,
-  `"","","Reave","1","PROTPALA1","-20","Shield Wall","","","tank external","","",""`,
-  `"","","Death from Above (PAR)","1,4","RSHAM1","0.5","Spirit Link Totem","","","","Pop SLT","",""`,
+  `"Paladino","","Reave","1","PROTPALA1","-20","Shield Wall","","","tank external","","",""`,
+  `"Totem","","Death from Above (PAR)","1,4","RSHAM1","0.5","Spirit Link Totem","","","","Pop SLT","",""`,
   `"","","Whirling","2","MELEEDPS","5","Custom Spell Assignment","","","bop priest","Lay on Hands","","633"`,
-  `"","","Hurl Amber","3","PROTPALA1","10","Custom Spell Assignment","","","","Void Shift","",""`,
+  `"Paladino","","Hurl Amber","3","PROTPALA1","10","Custom Spell Assignment","","","","Void Shift","",""`,
 ];
 
 const HEADER = '"Player","CD #","BOSS HEALTH / SPELL","COUNT / HEALTH %","PLAYER/CLASS/ALL","TIME","COOLDOWN SPELL","","NPC NAME","ADDITIONAL TEXT","OVERRIDE TTS","CUSTOM NAME","CUSTOM ICON"';

--- a/test/unit/serializer-validation.test.ts
+++ b/test/unit/serializer-validation.test.ts
@@ -139,5 +139,8 @@ test('T1: validation requires a resolved boss and an assignments array', () => {
 });
 
 test('T1: GROUP_TAGS is the canonical group-tag set', () => {
-  assert.deepEqual([...GROUP_TAGS], ['ALL', 'MELEEDPS', 'RANGEDDPS']);
+  assert.deepEqual([...GROUP_TAGS], [
+    'ALL', 'MELEEDPS', 'RANGEDDPS', 'TANKS', 'HEALERS',
+    'DEATHKNIGHT', 'DRUID', 'HUNTER', 'MAGE', 'MONK', 'PALADIN', 'PRIEST', 'ROGUE', 'SHAMAN', 'WARLOCK', 'WARRIOR',
+  ]);
 });

--- a/test/unit/serializer-validation.test.ts
+++ b/test/unit/serializer-validation.test.ts
@@ -110,12 +110,16 @@ test('T1: backward compatibility — legacy plan without tts/cd and single-numbe
   assert.equal(r.ok, true);
 });
 
-test('T1: occurrence accepts a single count or a comma-list; rejects malformed lists and negatives', () => {
+test('T1: occurrence accepts a single count, a comma-list, and the pre-event sentinel -1; rejects malformed lists, fractions, and negative lists (-3)', () => {
   const ok1 = validateAssignments([base({ occurrence: '1,4' })], { boss: paragons, roleMappings: ROLE_MAPPINGS });
   assert.equal(ok1.ok, true, JSON.stringify(ok1.errors));
   const ok2 = validateAssignments([base({ occurrence: '1, 4' })], { boss: paragons, roleMappings: ROLE_MAPPINGS });
   assert.equal(ok2.ok, true);
+  // -1 is a legit pre-event/countdown call in the reference kill set
+  assert.equal(validateAssignments([base({ occurrence: -1 })], { boss: paragons, roleMappings: ROLE_MAPPINGS }).ok, true);
   assert.equal(validateAssignments([base({ occurrence: '1.5' })], { boss: paragons, roleMappings: ROLE_MAPPINGS }).ok, false);
+  // a negative is only legal as the lone sentinel -1, not inside a list or other negatives
+  assert.equal(validateAssignments([base({ occurrence: '-1,3' })], { boss: paragons, roleMappings: ROLE_MAPPINGS }).ok, false);
   assert.equal(validateAssignments([base({ occurrence: -3 })], { boss: paragons, roleMappings: ROLE_MAPPINGS }).ok, false);
 });
 


### PR DESCRIPTION
## Summary

Clean rebuild of the col-A player-binding fix + supporting serializer/generator improvements, **excluding private artifacts** that were in the superseded #36 (agent session memory, captured reference payloads, tonight's runtime raft artifacts — removed per operator direction).

## Changes (8 commits)

- **fix(render)**: bind player names to col A; push re-renders from `committed.json` (removes stale `sheets-rows.json` dependency).
- **fix(generate)**: inject canonical event whitelist + accept null timeline.
- **feat(serializer)**: expand `GROUP_TAGS` to the sheet's group vocabulary; allow pre-event sentinel `-1` occurrence for countdown calls.
- **docs**: R2 agent-surface findings, community-analysis-engine design (SQLite corpus + Agent Canvas cron), R3 statistician-agent research, next-steps.

## Tests

`npm test` → **75/75 pass** on this rebuilt tree.

## Not included (removed per operator)

- `.openhands/memory/*`, `ref/`, `tonight/`, `docs/working-session-2026-08-22.md` — all private/transient.
- `.gitignore` hardened (`.openhands/`, `ref/`, `tonight/`, `*.csv`) to prevent re-sweep.